### PR TITLE
Add support to configure content security policy header

### DIFF
--- a/playground/contrib/generate-config-env.sh
+++ b/playground/contrib/generate-config-env.sh
@@ -28,7 +28,7 @@ EOF
 generate_nginx() {
     conf_template=$1
     nginx_conf=$2
-    envsubst '$PLAYGROUND_DEVELOPER_API_DOWNLOAD_ENDPOINT' < "$conf_template" > "$nginx_conf"
+    envsubst '$PLAYGROUND_DEVELOPER_API_DOWNLOAD_ENDPOINT,$HEADER_CONTENT_SECURITY_POLICY' < "$conf_template" > "$nginx_conf"
     echo "${nginx_conf}:"
     cat "$nginx_conf"
 }

--- a/playground/contrib/nginx.conf.tmpl
+++ b/playground/contrib/nginx.conf.tmpl
@@ -20,27 +20,27 @@ http {
         etag on;
         location / {
             try_files $uri $uri/ /index.html;
-            add_header Content-Security-Policy "frame-ancestors 'self';" always;
+            add_header Content-Security-Policy "frame-ancestors 'self' ${HEADER_CONTENT_SECURITY_POLICY};" always;
         }
         location /static/ {
             add_header Cache-Control max-age=31536000;
-            add_header Content-Security-Policy "frame-ancestors 'self';" always;
+            add_header Content-Security-Policy "frame-ancestors 'self' ${HEADER_CONTENT_SECURITY_POLICY};" always;
         }
         location /index.html {
             add_header Cache-Control no-cache;
-            add_header Content-Security-Policy "frame-ancestors 'self';" always;
+            add_header Content-Security-Policy "frame-ancestors 'self' ${HEADER_CONTENT_SECURITY_POLICY};" always;
         }
         location /config.json {
             add_header Cache-Control no-cache;
-            add_header Content-Security-Policy "frame-ancestors 'self';" always;
+            add_header Content-Security-Policy "frame-ancestors 'self' ${HEADER_CONTENT_SECURITY_POLICY};" always;
         }
         location /config-env.js {
             add_header Cache-Control no-cache;
-            add_header Content-Security-Policy "frame-ancestors 'self';" always;
+            add_header Content-Security-Policy "frame-ancestors 'self' ${HEADER_CONTENT_SECURITY_POLICY};" always;
         }
         location ~ ^/s/([^/]+)/download$ {
             rewrite ^/s/([^/]+)/download$ ${PLAYGROUND_DEVELOPER_API_DOWNLOAD_ENDPOINT}/$1;
-            add_header Content-Security-Policy "frame-ancestors 'self';" always;
+            add_header Content-Security-Policy "frame-ancestors 'self' ${HEADER_CONTENT_SECURITY_POLICY};" always;
         }
     }
 }

--- a/playground/craco.config.js
+++ b/playground/craco.config.js
@@ -3,6 +3,9 @@ const CracoEsbuildPlugin = require('craco-esbuild');
 const path = require('path');
 const { DefinePlugin } = require('webpack');
 
+const HEADER_CONTENT_SECURITY_POLICY =
+  process.env.HEADER_CONTENT_SECURITY_POLICY || '';
+
 const resolvePackage = (relativePath) => {
   return path.resolve(__dirname, relativePath);
 };
@@ -14,7 +17,7 @@ module.exports = {
       return webpackConfig;
     },
     headers: {
-      'Content-Security-Policy': "frame-ancestors 'self'",
+      'Content-Security-Policy': `frame-ancestors 'self' ${HEADER_CONTENT_SECURITY_POLICY}`,
     },
   },
   plugins: [

--- a/scripts/copy-build.sh
+++ b/scripts/copy-build.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env sh
 
+get_env_or_empty() {
+    local var_name="$1"
+    local var_value="${!var_name}"
+    echo "${var_value:-}"
+}
+
 cp wasm/*.wasm  playground/build/static
 mkdir -p playground/build/static/schemas
 cp -R examples/schemas/* playground/build/static/schemas
@@ -7,3 +13,8 @@ ls playground/build/static/schemas > playground/build/static/schemas/_all
 
 mkdir -p build
 cp -R playground/build/* build
+
+HEADER_VAL=$(get_env_or_empty "HEADER_CONTENT_SECURITY_POLICY")
+
+# Note: Using platform independent hack for in-place edit
+sed -i.bak -e "s/\$HEADER_CONTENT_SECURITY_POLICY/$HEADER_VAL/g" vercel.json

--- a/scripts/copy-build.sh
+++ b/scripts/copy-build.sh
@@ -1,11 +1,5 @@
 #!/usr/bin/env sh
 
-get_env_or_empty() {
-    local var_name="$1"
-    local var_value="${!var_name}"
-    echo "${var_value:-}"
-}
-
 cp wasm/*.wasm  playground/build/static
 mkdir -p playground/build/static/schemas
 cp -R examples/schemas/* playground/build/static/schemas
@@ -13,8 +7,3 @@ ls playground/build/static/schemas > playground/build/static/schemas/_all
 
 mkdir -p build
 cp -R playground/build/* build
-
-HEADER_VAL=$(get_env_or_empty "HEADER_CONTENT_SECURITY_POLICY")
-
-# Note: Using platform independent hack for in-place edit
-sed -i.bak -e "s/\$HEADER_CONTENT_SECURITY_POLICY/$HEADER_VAL/g" vercel.json

--- a/vercel.json
+++ b/vercel.json
@@ -9,7 +9,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "frame-ancestors 'self';"
+          "value": "frame-ancestors 'self' $HEADER_CONTENT_SECURITY_POLICY;"
         }
       ]
     },
@@ -22,7 +22,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "frame-ancestors 'self';"
+          "value": "frame-ancestors 'self' $HEADER_CONTENT_SECURITY_POLICY;"
         }
       ]
     },
@@ -35,7 +35,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "frame-ancestors 'self';"
+          "value": "frame-ancestors 'self' $HEADER_CONTENT_SECURITY_POLICY;"
         }
       ]
     },
@@ -48,7 +48,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "frame-ancestors 'self';"
+          "value": "frame-ancestors 'self' $HEADER_CONTENT_SECURITY_POLICY;"
         }
       ]
     },
@@ -57,7 +57,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "frame-ancestors 'self';"
+          "value": "frame-ancestors 'self' $HEADER_CONTENT_SECURITY_POLICY;"
         }
       ]
     }

--- a/vercel.json
+++ b/vercel.json
@@ -9,7 +9,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "frame-ancestors 'self' $HEADER_CONTENT_SECURITY_POLICY;"
+          "value": "frame-ancestors 'self' docs.authzed.com authzed.com www.authzed.com;"
         }
       ]
     },
@@ -22,7 +22,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "frame-ancestors 'self' $HEADER_CONTENT_SECURITY_POLICY;"
+          "value": "frame-ancestors 'self' docs.authzed.com authzed.com www.authzed.com;"
         }
       ]
     },
@@ -35,7 +35,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "frame-ancestors 'self' $HEADER_CONTENT_SECURITY_POLICY;"
+          "value": "frame-ancestors 'self' docs.authzed.com authzed.com www.authzed.com;"
         }
       ]
     },
@@ -48,7 +48,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "frame-ancestors 'self' $HEADER_CONTENT_SECURITY_POLICY;"
+          "value": "frame-ancestors 'self' docs.authzed.com authzed.com www.authzed.com;"
         }
       ]
     },
@@ -57,7 +57,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "frame-ancestors 'self' $HEADER_CONTENT_SECURITY_POLICY;"
+          "value": "frame-ancestors 'self' docs.authzed.com authzed.com www.authzed.com;"
         }
       ]
     }


### PR DESCRIPTION
Add ability to configure the Content-Security-Policy header value. This enables embedding playground instances on external sites. 

Supports building playground as a docker image, via craco, and on Vercel.