### PR TITLE
Fix doc links on playground tabs

### DIFF
--- a/playground/src/components/FullPlayground.tsx
+++ b/playground/src/components/FullPlayground.tsx
@@ -1115,7 +1115,7 @@ export function ThemedAppView(props: { datastore: DataStore }) {
           {currentItem?.kind === DataStoreItemKind.ASSERTIONS && (
             <Button
               className={classes.docsLink}
-              href="https://authzed.com/docs/spicedb/modeling/developing-a-schema#writing-assertions"
+              href="https://authzed.com/docs/spicedb/modeling/developing-a-schema#assertions"
               target="_blank"
               startIcon={<DescriptionIcon />}
             >
@@ -1126,7 +1126,7 @@ export function ThemedAppView(props: { datastore: DataStore }) {
           {currentItem?.kind === DataStoreItemKind.EXPECTED_RELATIONS && (
             <Button
               className={classes.docsLink}
-              href="https://authzed.com/docs/spicedb/modeling/developing-a-schema#writing-expected-relations"
+              href="https://authzed.com/docs/spicedb/modeling/developing-a-schema#expected-relations"
               target="_blank"
               startIcon={<DescriptionIcon />}
             >


### PR DESCRIPTION
This fixes the links on the assertions and expected relations page.

The relationship link still points to https://authzed.com/docs/spicedb/modeling/developing-a-schema#creating-test-relationships which I couldn't find a good replacement for. 