### PR TITLE
Add support for download API in vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -53,6 +53,15 @@
       ]
     },
     {
+      "source": "/s/:path([^/]+)/download",
+      "headers": [
+        {
+          "key": "Content-Security-Policy",
+          "value": "frame-ancestors 'self' docs.authzed.com authzed.com www.authzed.com;"
+        }
+      ]
+    },
+    {
       "source": "/(.*)",
       "headers": [
         {
@@ -60,6 +69,12 @@
           "value": "frame-ancestors 'self' docs.authzed.com authzed.com www.authzed.com;"
         }
       ]
+    }
+  ],
+  "rewrites": [
+    {
+      "source": "/s/:path([^/]+)/download",
+      "destination": "https://download.developer.authzed.com/:path*"
     }
   ]
 }


### PR DESCRIPTION
Connect the AuthZed hosted playground to the download service to re-enable zed import and schema download functionality.