### PR TITLE
Fix share loading

### DIFF
--- a/src/components/ShareLoader.tsx
+++ b/src/components/ShareLoader.tsx
@@ -68,6 +68,7 @@ export function ShareLoader(props: {
         }
         const service = new DeveloperServiceClient(new GrpcWebFetchTransport({ baseUrl: endpoint }));
 
+        // TODO: use routing for this instead of string manipulation
       const pieces = location.pathname.replace(urlPrefix, "").split('/');
       if (pieces.length < 1 && !props.sharedRequired) {
         history.push('/');

--- a/src/components/ShareLoader.tsx
+++ b/src/components/ShareLoader.tsx
@@ -68,7 +68,7 @@ export function ShareLoader(props: {
         }
         const service = new DeveloperServiceClient(new GrpcWebFetchTransport({ baseUrl: endpoint }));
 
-      const pieces = location.pathname.slice(0, urlPrefix.length).split('/');
+      const pieces = location.pathname.replace(urlPrefix, "").split('/');
       if (pieces.length < 1 && !props.sharedRequired) {
         history.push('/');
         return;


### PR DESCRIPTION
## Description
I broke this in #36 when I grabbed the wrong part of the URL (the prefix instead of the suffix). This meant that the request was always for the share with the identifier of the empty string.

## Changes
* Grab the right part of the URL
* Add a TODO to do this with routing instead

## Testing
Review. See that shares work once it's merged.