### PR TITLE
Fix check watches after protobuf-es change

### DIFF
--- a/src/components/panels/watches.tsx
+++ b/src/components/panels/watches.tsx
@@ -295,14 +295,14 @@ export function WatchesPanel(props: PanelProps<PlaygroundPanelLocation>) {
   );
 }
 
+function notNull(value: string | null): value is string {
+  return value !== null;
+}
+
 const filter = (values: (string | null)[]): string[] => {
-  const filtered = values.filter((v: string | null) => !!v);
+  const filtered = values.filter(notNull);
   const set = new Set(filtered);
-  const deduped: string[] = [];
-  set.forEach((value: string | null) => {
-    deduped.push(value!);
-  });
-  return deduped;
+  return Array.from(set);
 };
 
 function LiveCheckRow(props: {

--- a/src/spicedb-common/services/developerservice.ts
+++ b/src/spicedb-common/services/developerservice.ts
@@ -22,7 +22,7 @@ import {
   DeveloperRequestSchema,
   DeveloperResponseSchema,
 } from "../protodefs/developer/v1/developer_pb";
-import { create, toJson } from "@bufbuild/protobuf";
+import { create, fromJsonString, toJsonString } from "@bufbuild/protobuf";
 import wasmConfig from "../../wasm-config.json";
 
 const WASM_FILE = `/static/main.wasm`;
@@ -226,16 +226,13 @@ class DeveloperServiceRequest {
       ),
     });
 
-    const developerRequest = JSON.stringify(
-      toJson(DeveloperRequestSchema, request),
-    );
+    const developerRequest = toJsonString(DeveloperRequestSchema, request);
     const encodedResponse: string =
       window[ENTRYPOINT_FUNCTION](developerRequest);
 
-    const response = create(
-      DeveloperResponseSchema,
-      JSON.parse(encodedResponse),
-    );
+    const response = fromJsonString(DeveloperResponseSchema, encodedResponse, {
+      ignoreUnknownFields: true,
+    });
     if (this.operations.length > 0 && response.operationsResults) {
       this.operations.forEach((osc, index) => {
         const result = response.operationsResults?.results[index];


### PR DESCRIPTION
## Description
Follow-on to #70. I reached for the wrong helper functions for serialization/deserialization, which meant that the comparisons were wrong. This fixes that.

## Changes
Will annotate.

## Testing
Review. See that check watches still work as expected locally.