### PR TITLE
Fix relationship editor column offset bugs

### DIFF
--- a/src/components/relationshipeditor/RelationshipEditor.tsx
+++ b/src/components/relationshipeditor/RelationshipEditor.tsx
@@ -601,8 +601,7 @@ export function RelationshipEditor({
       return false;
     }
 
-    const [oneIndexedColumn, startingRow] = target;
-    const startingCol = oneIndexedColumn - 1; // col is +1 for the checkbox.
+    const [startingCol, startingRow] = target;
 
     let adjustedData = inFlightData.current;
     let rowOffset = 0;

--- a/src/components/relationshipeditor/columns.ts
+++ b/src/components/relationshipeditor/columns.ts
@@ -107,6 +107,9 @@ export const COLUMNS: Column[] = [
     group: "Resource",
     dataKind: DataKind.RESOURCE_TYPE,
     section: RelationshipSection.RESOURCE,
+    trailingRowOptions: {
+      hint: "Add relationship",
+    },
     dataDescription: "definition name",
   },
   {
@@ -116,10 +119,6 @@ export const COLUMNS: Column[] = [
     group: "Resource",
     dataKind: DataKind.RESOURCE_ID,
     section: RelationshipSection.RESOURCE,
-    trailingRowOptions: {
-      hint: "Add relationship",
-      targetColumn: 0,
-    },
     dataDescription: "object ID",
   },
   {


### PR DESCRIPTION
Fixes #66

- Move "Add relationship" hint from ID column to Type column
- Fix off-by-one in paste handler (glide-data-grid provides 0-indexed columns, not 1-indexed)

<img width="870" height="609" alt="Screenshot 2026-02-17 at 10 48 16 AM" src="https://github.com/user-attachments/assets/08308e14-622d-4cc6-91ca-3fd817547f2c" />
