### PR TITLE
Disable edge connection handles in visualizers

### DIFF
--- a/src/components/visualizer/RelationshipGraph.tsx
+++ b/src/components/visualizer/RelationshipGraph.tsx
@@ -275,6 +275,7 @@ export default function RelationshipGraph({ relationships }: RelationshipGraphPr
         edges={edges}
         onEdgeMouseEnter={handleEdgeMouseEnter}
         onEdgeMouseLeave={handleEdgeMouseLeave}
+        nodesConnectable={false}
         colorMode="system"
         fitView
         attributionPosition="bottom-left"

--- a/src/components/visualizer/RelationshipNode.tsx
+++ b/src/components/visualizer/RelationshipNode.tsx
@@ -29,9 +29,9 @@ export function RelationshipNode({ data, selected }: NodeProps<RelationshipNodeT
         justifyContent: "center",
       }}
     >
-      <Handle type="source" position={Position.Top} />
+      <Handle type="source" position={Position.Top} className="!w-0 !h-0 !border-0 !bg-transparent" />
       <div className="text-center font-medium text-sm break-all">{data.label}</div>
-      <Handle type="target" position={Position.Bottom} />
+      <Handle type="target" position={Position.Bottom} className="!w-0 !h-0 !border-0 !bg-transparent" />
     </div>
   );
 }

--- a/src/components/visualizer/RelationshipNode.tsx
+++ b/src/components/visualizer/RelationshipNode.tsx
@@ -29,9 +29,17 @@ export function RelationshipNode({ data, selected }: NodeProps<RelationshipNodeT
         justifyContent: "center",
       }}
     >
-      <Handle type="source" position={Position.Top} className="!w-0 !h-0 !border-0 !bg-transparent" />
+      <Handle
+        type="source"
+        position={Position.Top}
+        className="!w-0 !h-0 !border-0 !bg-transparent"
+      />
       <div className="text-center font-medium text-sm break-all">{data.label}</div>
-      <Handle type="target" position={Position.Bottom} className="!w-0 !h-0 !border-0 !bg-transparent" />
+      <Handle
+        type="target"
+        position={Position.Bottom}
+        className="!w-0 !h-0 !border-0 !bg-transparent"
+      />
     </div>
   );
 }

--- a/src/components/visualizer/SchemaGraph.tsx
+++ b/src/components/visualizer/SchemaGraph.tsx
@@ -256,6 +256,7 @@ export default function SchemaGraph({ schema, relationships }: SchemaGraphProps)
         onNodesChange={onNodesChange}
         edges={edges}
         edgeTypes={edgeTypes}
+        nodesConnectable={false}
         colorMode="system"
         fitView
         attributionPosition="bottom-left"


### PR DESCRIPTION
Fixes #112

Disables the non-functional connection handles on schema and relationship visualizer nodes by setting `nodesConnectable={false}` and hiding the handle elements visually.

<img width="1769" height="1205" alt="Screenshot 2026-03-20 at 3 38 21 PM" src="https://github.com/user-attachments/assets/e0850277-d3bf-4130-8fed-1f363482a6c3" />

<img width="1769" height="1205" alt="Screenshot 2026-03-20 at 3 39 25 PM" src="https://github.com/user-attachments/assets/3dd85c82-597f-49dc-888c-50bb17892d45" />
