### PR TITLE
Improve text contrast in schema visualizer nodes

### DIFF
--- a/src/components/visualizer/RelationshipGraph.tsx
+++ b/src/components/visualizer/RelationshipGraph.tsx
@@ -275,6 +275,7 @@ export default function RelationshipGraph({ relationships }: RelationshipGraphPr
         edges={edges}
         onEdgeMouseEnter={handleEdgeMouseEnter}
         onEdgeMouseLeave={handleEdgeMouseLeave}
+        nodesConnectable={false}
         colorMode="system"
         fitView
         attributionPosition="bottom-left"

--- a/src/components/visualizer/RelationshipNode.tsx
+++ b/src/components/visualizer/RelationshipNode.tsx
@@ -1,4 +1,5 @@
 import { Handle, Position, NodeProps, Node } from "@xyflow/react";
+import { useMemo } from "react";
 
 import { RelationTuple as Relationship } from "@/spicedb-common/protodefs/core/v1/core_pb";
 
@@ -10,7 +11,38 @@ export type RelationshipNodeType = Node<{
   relationships: Relationship[];
 }>;
 
+/**
+ * Returns a foreground color (black or white) that contrasts well against
+ * the given CSS hex or rgb() background color.
+ */
+function contrastingTextColor(backgroundColor: string): string {
+  let r = 0,
+    g = 0,
+    b = 0;
+
+  if (backgroundColor.startsWith("#")) {
+    const hex = backgroundColor.replace("#", "");
+    r = parseInt(hex.substring(0, 2), 16);
+    g = parseInt(hex.substring(2, 4), 16);
+    b = parseInt(hex.substring(4, 6), 16);
+  } else {
+    const match = backgroundColor.match(/\d+/g);
+    if (match && match.length >= 3) {
+      r = parseInt(match[0], 10);
+      g = parseInt(match[1], 10);
+      b = parseInt(match[2], 10);
+    }
+  }
+
+  // WCAG relative luminance
+  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+  return luminance > 0.5 ? "#000000" : "#ffffff";
+}
+
 export function RelationshipNode({ data, selected }: NodeProps<RelationshipNodeType>) {
+  const bg = data.backgroundColor || "#ffffff";
+  const textColor = useMemo(() => contrastingTextColor(bg), [bg]);
+
   return (
     <div
       // TODO: use twmerge/clsx for this.
@@ -21,7 +53,8 @@ export function RelationshipNode({ data, selected }: NodeProps<RelationshipNodeT
       `}
       // TODO: use tailwind for this.
       style={{
-        backgroundColor: data.backgroundColor || "#ffffff",
+        backgroundColor: bg,
+        color: textColor,
         minWidth: "200px",
         minHeight: "80px",
         display: "flex",

--- a/src/components/visualizer/SchemaGraph.tsx
+++ b/src/components/visualizer/SchemaGraph.tsx
@@ -256,6 +256,7 @@ export default function SchemaGraph({ schema, relationships }: SchemaGraphProps)
         onNodesChange={onNodesChange}
         edges={edges}
         edgeTypes={edgeTypes}
+        nodesConnectable={false}
         colorMode="system"
         fitView
         attributionPosition="bottom-left"


### PR DESCRIPTION
Fixes #113

Adds WCAG-based luminance check to auto-select black or white text based on the node's background color, ensuring labels are always readable.

<img width="1769" height="1205" alt="Screenshot 2026-03-20 at 3 30 03 PM" src="https://github.com/user-attachments/assets/176ca37e-05f0-489d-bbae-82aa4a6e584b" />
