### PR TITLE
Fix syntax highlighting of self keyword

### DIFF
--- a/src/spicedb-common/lang/dslang.ts
+++ b/src/spicedb-common/lang/dslang.ts
@@ -239,6 +239,7 @@ export default function registerDSLanguage(monaco: typeof monacoEditor) {
         [/any/, { token: "keyword.any", next: "@arrowopen" }],
         [/all/, { token: "keyword.all", next: "@arrowopen" }],
         [/nil/, { token: "keyword.nil" }],
+        [/self/, { token: "keyword.self" }],
         [/\w+/, { token: "identifier.relorperm" }],
         { include: "@whitespace" },
       ],
@@ -503,6 +504,9 @@ export default function registerDSLanguage(monaco: typeof monacoEditor) {
 
           case "expression":
             if (resolved.resolvedRelationOrPermission === undefined) {
+              if (resolved.reference.relationName === "self") {
+                break;
+              }
               appendData(
                 lineNumber,
                 colPosition,
@@ -577,6 +581,7 @@ export default function registerDSLanguage(monaco: typeof monacoEditor) {
       { token: "keyword.definition", foreground: "4242ff" },
       { token: "keyword.caveat", foreground: "ff4271" },
       { token: "keyword.nil", foreground: "999999" },
+      { token: "keyword.self", foreground: "999999" },
       { token: "keyword.any", foreground: "23974d" },
       { token: "keyword.all", foreground: "972323" },
 
@@ -623,6 +628,7 @@ export default function registerDSLanguage(monaco: typeof monacoEditor) {
     { token: "keyword.definition", foreground: "8787ff" },
     { token: "keyword.caveat", foreground: "ff87a6" },
     { token: "keyword.nil", foreground: "cccccc" },
+    { token: "keyword.self", foreground: "cccccc" },
     { token: "keyword.any", foreground: "abe5ff" },
     { token: "keyword.all", foreground: "ffabab" },
 


### PR DESCRIPTION
Fixes #104.

## Description
The `self` keyword in permission expressions was incorrectly highlighted in red, as if it were an unknown reference.

## Changes
* Add `self` as a recognized keyword token in the Monarch tokenizer
* Skip `self` in the semantic tokens provider so it isn't overridden as `property.unknown`
* Add `keyword.self` theme entries for both light and dark themes

<img width="499" height="699" alt="Screenshot 2026-03-27 at 12 38 53 PM" src="https://github.com/user-attachments/assets/dea4e842-f5a9-4e8a-a183-9432d4bc5b5b" />
