### PR TITLE
fix: resolve consent state initialization issue

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -72,6 +72,15 @@ function PHProvider({ children }: PropsWithChildren) {
         opt_out_persistence_by_default: optOut,
         cookieless_mode: "on_reject",
       });
+
+      // cookieless_mode "on_reject" treats PENDING consent as opted-out and
+      // non-capturing. Move every visitor out of PENDING so that opted-out
+      // users get cookieless tracking and opted-in users get full tracking.
+      if (optOut) {
+        posthog.opt_out_capturing();
+      } else if (!posthog.has_opted_in_capturing()) {
+        posthog.opt_in_capturing();
+      }
     }
   }, []);
 


### PR DESCRIPTION
## Summary
- Ensures explicit consent state is set after SDK init so that the cookieless mode configuration works as intended for all visitors
- Opted-out visitors now correctly enter cookieless mode; opted-in visitors get full tracking

## Test plan
- [ ] Verify non-EU visitors see events flowing after deploy
- [ ] Verify EU visitors without consent cookie get cookieless tracking
- [ ] Verify visitors with `az-consent` cookie respected correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)