### PR TITLE
chore: fix broken Docs nav link

### DIFF
--- a/src/components/FullPlayground.tsx
+++ b/src/components/FullPlayground.tsx
@@ -710,7 +710,7 @@ export function ThemedAppView(props: {
         <Tooltip>
           <TooltipTrigger asChild>
             <Button asChild size="sm" variant="ghost">
-              <a href="https://authzed.com/docs/spicedb" target="_blank" rel="noreferrer">
+              <a href="https://authzed.com/docs/" target="_blank" rel="noreferrer">
                 <BookOpenText />
                 <span className="hidden xl:inline">Docs</span>
               </a>


### PR DESCRIPTION
## Summary

- Fixes 404 on the Docs nav link by updating the href from `https://authzed.com/docs/spicedb` to `https://authzed.com/docs/`

## Test plan

- [ ] Click the Docs button in the playground nav and confirm it navigates to the authzed docs without a 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)