### PR TITLE
Update Nginx to 1.27 and optimize apt-get cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,9 @@ RUN yarn build
 
 FROM $BASE_IMAGE AS playground-verifier
 
-FROM nginx:1.25.2
+FROM nginx:1.27
 LABEL maintainer="AuthZed <support@authzed.com>"
+RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
 EXPOSE 3000
 ENV PORT=3000
 


### PR DESCRIPTION
## Description

Upgrades the final-stage base image from `nginx:1.25.2` (August 2023) to `nginx:1.27` and adds an `apt-get upgrade` step to pick up all available Debian 12 security patches at build time.

This resolves all fixable CVEs flagged by Wiz scanning, including 3 critical policy-failing vulnerabilities:
- **CVE-2024-37371** (libkrb5/libk5crypto3) — unauthenticated remote code execution
- **CVE-2024-45491** (libexpat1) — integer overflow
- **CVE-2024-45492** (libexpat1) — integer overflow

Also fixes ~12 HIGH-severity CVEs across libkrb5, libexpat1, perl-base, libpam, libdav1d6, and libavif15.

## Testing

- Rebuild the image and verify nginx starts correctly: `docker build -t spicedb-playground . && docker run -p 3000:3000 spicedb-playground`
- Re-run Wiz scan against the new image to confirm policy-failing CVEs are resolved
- Verify the playground loads correctly at `localhost:3000`

## References

Wiz scan output for `ghcr.io/authzed/spicedb-playground:v0.3.1` showing critical vulnerability policy failures
