### PR TITLE
feat: add check watch from failing assertion

### DIFF
--- a/src/components/EditorDisplay.tsx
+++ b/src/components/EditorDisplay.tsx
@@ -10,6 +10,7 @@ import { flushSync } from "react-dom";
 import { useSettings } from "@/components/SettingsProvider";
 import { useResolvedTheme } from "@/hooks/use-resolved-theme";
 
+import { assertionStringToCheckWatch, CheckWatch, LiveCheckService } from "../services/check";
 import { ScrollLocation, useCookieService } from "../services/cookieservice";
 import { DataStore, DataStoreItem, DataStoreItemKind } from "../services/datastore";
 import { LocalParseState } from "../services/localparse";
@@ -22,6 +23,7 @@ import registerDSLanguage, {
 import { RelationshipFound } from "../spicedb-common/parsing";
 import {
   DeveloperError,
+  DeveloperError_Source,
   DeveloperWarning,
 } from "../spicedb-common/protodefs/developer/v1/developer_pb";
 
@@ -37,6 +39,13 @@ import registerTupleLanguage, { TUPLE_LANGUAGE_NAME } from "./relationshipeditor
 // state without re-registering.
 let languagesRegistered = false;
 const latestLocalParseStateRef: { current: LocalParseState | null } = { current: null };
+
+// Holds the current LiveCheckService for the assertions-quickfix command,
+// which is registered once at module scope and therefore can't close over a
+// React-owned reference.
+const latestLiveCheckServiceRef: { current: LiveCheckService | null } = { current: null };
+
+const ADD_CHECK_WATCH_COMMAND_ID = "playground.addCheckWatchFromAssertion";
 
 export type EditorDisplayProps = {
   datastore: DataStore;
@@ -74,6 +83,12 @@ export function EditorDisplay(props: EditorDisplayProps) {
   useEffect(() => {
     latestLocalParseStateRef.current = props.services.localParseService.state;
   }, [props.services.localParseService.state]);
+
+  // Same trick for the assertions quick-fix command.
+  latestLiveCheckServiceRef.current = props.services.liveCheckService;
+  useEffect(() => {
+    latestLiveCheckServiceRef.current = props.services.liveCheckService;
+  }, [props.services.liveCheckService]);
 
   const location = useLocation();
 
@@ -248,10 +263,13 @@ export function EditorDisplay(props: EditorDisplayProps) {
       const trimmedContext = rawContext.trim();
       const isSingleWordToken = !!trimmedContext && !/\s/.test(trimmedContext);
 
+      // The assertions runner emits line numbers that don't reliably point at
+      // the failing assertion in the YAML source. Ignore the reported line for
+      // assertion errors and locate the assertion text in the document.
+      const ignoreReportedLine = isSingleWordToken && de.source === DeveloperError_Source.ASSERTION;
+
       if (isSingleWordToken) {
-        // If there is no line information, search the entire document for the
-        // first occurrence of the trimmed context.
-        if (!line) {
+        if (!line || ignoreReportedLine) {
           const index = contents.indexOf(trimmedContext);
           if (index >= 0) {
             const found = finder.fromIndex(index);
@@ -262,9 +280,9 @@ export function EditorDisplay(props: EditorDisplayProps) {
             }
           }
         } else {
-          // Anchor to the actual occurrence of the trimmed context on (or near)
-          // the reported line. This is robust against off-by-one / 0-vs-1
-          // indexed columns coming from different error producers.
+          // Anchor to the actual occurrence of the trimmed context on the
+          // reported line. Robust against off-by-one / 0-vs-1 column indexing
+          // from different error producers.
           const lineText = lines[line - 1] ?? "";
           const searchFrom = Math.max(0, (column ?? 1) - 1);
           let onLineIndex = lineText.indexOf(trimmedContext, searchFrom);
@@ -397,6 +415,7 @@ export function EditorDisplay(props: EditorDisplayProps) {
     if (!languagesRegistered) {
       registerDSLanguage(monacoInstance);
       registerTupleLanguage(monacoInstance, () => latestLocalParseStateRef.current!);
+      registerAssertionFixes(monacoInstance);
       languagesRegistered = true;
       // Themes are defined inside registerDSLanguage. The Editor already rendered
       // with the theme prop before defineTheme ran, so Monaco fell back to its
@@ -638,4 +657,67 @@ export function EditorDisplay(props: EditorDisplayProps) {
       )}
     </div>
   );
+}
+
+/**
+ * registerAssertionFixes wires a CodeLens above each failing-assertion marker
+ * that materializes the assertion as a Check Watch row. Registered once at
+ * module scope; reads the latest LiveCheckService via a module-level ref
+ * since the command handler can't close over a React-owned reference.
+ *
+ * A lightbulb CodeAction would be the natural fit here, but Monaco's
+ * lightbulb widget shifts its icon to an adjacent line when the marker's
+ * line indent is narrower than the icon (~22px). For 2-space YAML indents
+ * this puts the bulb on the wrong line, so we use a CodeLens — which renders
+ * directly above the failing assertion regardless of indent.
+ */
+function registerAssertionFixes(monacoInstance: typeof monaco) {
+  monacoInstance.editor.registerCommand(
+    ADD_CHECK_WATCH_COMMAND_ID,
+    (_accessor: unknown, watch: CheckWatch) => {
+      const service = latestLiveCheckServiceRef.current;
+      if (!service) return;
+      useDrawerStore.getState().openPanel("watches");
+      service.addWatch(watch);
+    },
+  );
+
+  // Refreshed whenever the owning model's markers change so the lens follows
+  // the marker as the user edits the YAML.
+  const codeLensProviderRef: { current: monaco.languages.CodeLensProvider | null } = {
+    current: null,
+  };
+  const codeLensEmitter = new monacoInstance.Emitter<monaco.languages.CodeLensProvider>();
+  monacoInstance.editor.onDidChangeMarkers(() => {
+    if (codeLensProviderRef.current) codeLensEmitter.fire(codeLensProviderRef.current);
+  });
+  const codeLensProvider: monaco.languages.CodeLensProvider = {
+    onDidChange: codeLensEmitter.event,
+    provideCodeLenses: (model) => {
+      const markers = monacoInstance.editor.getModelMarkers({ resource: model.uri });
+      const lenses: monaco.languages.CodeLens[] = [];
+      for (const marker of markers) {
+        if (marker.severity !== monacoInstance.MarkerSeverity.Error) continue;
+        const code = typeof marker.code === "string" ? marker.code : (marker.code?.value ?? "");
+        const watch = assertionStringToCheckWatch(code);
+        if (!watch) continue;
+        lenses.push({
+          range: {
+            startLineNumber: marker.startLineNumber,
+            startColumn: 1,
+            endLineNumber: marker.startLineNumber,
+            endColumn: 1,
+          },
+          command: {
+            id: ADD_CHECK_WATCH_COMMAND_ID,
+            title: "$(lightbulb) Add check watch for this assertion",
+            arguments: [watch],
+          },
+        });
+      }
+      return { lenses, dispose: () => undefined };
+    },
+  };
+  codeLensProviderRef.current = codeLensProvider;
+  monacoInstance.languages.registerCodeLensProvider("yaml", codeLensProvider);
 }

--- a/src/components/panels/problems.tsx
+++ b/src/components/panels/problems.tsx
@@ -1,9 +1,11 @@
-import { ChevronDown, ChevronRight, CircleX, Play, TriangleAlert } from "lucide-react";
+import { ChevronDown, ChevronRight, CircleX, Eye, Play, TriangleAlert } from "lucide-react";
 import * as React from "react";
 
 import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 
+import { assertionStringToCheckWatch, LiveCheckService } from "../../services/check";
 import { Services } from "../../services/services";
 import {
   DeveloperError,
@@ -11,6 +13,7 @@ import {
   DeveloperWarning,
 } from "../../spicedb-common/protodefs/developer/v1/developer_pb";
 import { DocumentLink } from "../document-link";
+import { useDrawerStore } from "../drawer/state";
 
 import { DeveloperSourceDisplay, DeveloperWarningSourceDisplay } from "./errordisplays";
 
@@ -22,13 +25,22 @@ export function ProblemsPanel({ services }: ProblemsPanelProps) {
   const requestErrors = services.problemService.requestErrors;
   const warnings = services.problemService.warnings;
   const invalidRels = services.problemService.invalidRelationships;
-  const validationErrors = services.problemService.validationErrors;
+  const allValidationErrors = services.problemService.validationErrors;
 
   const schemaErrors = requestErrors.filter((e) => e.source === DeveloperError_Source.SCHEMA);
   const relationshipRequestErrors = requestErrors.filter(
     (e) => e.source === DeveloperError_Source.RELATIONSHIP,
   );
-  const assertionErrors = requestErrors.filter((e) => e.source === DeveloperError_Source.ASSERTION);
+  // Assertion-source errors land in `validationErrors` (the validation runner
+  // is what executes the assertions block), not `requestErrors`. Pull them out
+  // so they show up under "Assertions" instead of "Validation".
+  const assertionErrors = [
+    ...requestErrors.filter((e) => e.source === DeveloperError_Source.ASSERTION),
+    ...allValidationErrors.filter((e) => e.source === DeveloperError_Source.ASSERTION),
+  ];
+  const validationErrors = allValidationErrors.filter(
+    (e) => e.source !== DeveloperError_Source.ASSERTION,
+  );
 
   return (
     <div className="p-2 space-y-1">
@@ -63,7 +75,11 @@ export function ProblemsPanel({ services }: ProblemsPanelProps) {
 
       <Group title="Assertions" errorCount={assertionErrors.length}>
         {assertionErrors.map((de, i) => (
-          <ErrorRow key={`a${i}`} error={de} />
+          <ErrorRow
+            key={`a${i}`}
+            error={de}
+            action={<AddCheckWatchAction error={de} liveCheckService={services.liveCheckService} />}
+          />
         ))}
       </Group>
 
@@ -170,7 +186,7 @@ function splitMessage(message: string): { summary: string; rest: string } {
   return { summary: trimmed, rest: "" };
 }
 
-function ErrorRow({ error }: { error: DeveloperError }) {
+function ErrorRow({ error, action }: { error: DeveloperError; action?: React.ReactNode }) {
   const { summary, rest } = splitMessage(error.message);
   return (
     <div className="flex items-start gap-3 border-l-2 border-l-destructive bg-card px-3 py-2">
@@ -194,7 +210,34 @@ function ErrorRow({ error }: { error: DeveloperError }) {
           )}
         </div>
       </div>
+      {action && <div className="shrink-0">{action}</div>}
     </div>
+  );
+}
+
+function AddCheckWatchAction({
+  error,
+  liveCheckService,
+}: {
+  error: DeveloperError;
+  liveCheckService: LiveCheckService;
+}) {
+  const watch = React.useMemo(() => assertionStringToCheckWatch(error.context), [error.context]);
+  if (!watch) return null;
+  const onClick = () => {
+    useDrawerStore.getState().openPanel("watches");
+    liveCheckService.addWatch(watch);
+  };
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button size="xs" variant="ghost" onClick={onClick}>
+          <Eye />
+          Add check watch
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>Add check watch for this assertion</TooltipContent>
+    </Tooltip>
   );
 }
 

--- a/src/components/panels/watches.tsx
+++ b/src/components/panels/watches.tsx
@@ -118,6 +118,7 @@ export function WatchesPanel({ services, datastore }: WatchesPanelProps) {
               editorUpdateIndex={editorUpdateIndex}
               datastore={datastore}
               item={item}
+              flashHighlight={liveCheckService.recentlyAddedItemId === item.id}
             />
           ))}
         </TableBody>
@@ -141,6 +142,7 @@ interface LiveCheckRowProps {
   editorUpdateIndex?: number;
   datastore: DataStore;
   localParseService: LocalParseService;
+  flashHighlight?: boolean;
 }
 
 function LiveCheckRow(props: LiveCheckRowProps) {
@@ -260,7 +262,7 @@ function LiveCheckRow(props: LiveCheckRowProps) {
           </TableCell>
         </TableRow>
       )}
-      <TableRow>
+      <TableRow data-flash-highlight={props.flashHighlight ? "true" : undefined}>
         <TableCell className="w-8 px-1 align-middle">
           {item.debugInformation !== undefined && (
             <Button size="icon-xs" variant="ghost" onClick={() => setIsExpanded(!isExpanded)}>

--- a/src/index.css
+++ b/src/index.css
@@ -157,3 +157,18 @@ code {
     @apply bg-background text-foreground;
   }
 }
+
+/* Brief flash applied to a newly-added Check Watch row so the user can locate
+ * it after the drawer auto-switches to the Check Watches panel. */
+@keyframes flash-highlight {
+  from {
+    background-color: color-mix(in oklch, var(--primary) 35%, transparent);
+  }
+  to {
+    background-color: transparent;
+  }
+}
+
+[data-flash-highlight="true"] > td {
+  animation: flash-highlight 1s ease-out;
+}

--- a/src/services/check.test.ts
+++ b/src/services/check.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import { assertionStringToCheckWatch } from "./check";
+
+describe("assertionStringToCheckWatch", () => {
+  it("parses a simple assertion", () => {
+    expect(assertionStringToCheckWatch("document:firstdoc#view@user:fred")).toEqual({
+      object: "document:firstdoc",
+      action: "view",
+      subject: "user:fred",
+      context: "",
+    });
+  });
+
+  it("strips a trailing #... on the subject", () => {
+    expect(assertionStringToCheckWatch("document:firstdoc#view@user:fred#...")).toEqual({
+      object: "document:firstdoc",
+      action: "view",
+      subject: "user:fred",
+      context: "",
+    });
+  });
+
+  it("preserves a non-trivial subject relation", () => {
+    expect(assertionStringToCheckWatch("document:firstdoc#view@team:eng#member")).toEqual({
+      object: "document:firstdoc",
+      action: "view",
+      subject: "team:eng#member",
+      context: "",
+    });
+  });
+
+  it("extracts a caveat context", () => {
+    expect(
+      assertionStringToCheckWatch('document:firstdoc#view@user:fred[some_caveat:{"hour":12}]'),
+    ).toEqual({
+      object: "document:firstdoc",
+      action: "view",
+      subject: "user:fred",
+      context: 'some_caveat:{"hour":12}',
+    });
+  });
+
+  it("returns undefined for malformed strings", () => {
+    expect(assertionStringToCheckWatch("")).toBeUndefined();
+    expect(assertionStringToCheckWatch("not-a-relationship")).toBeUndefined();
+    expect(assertionStringToCheckWatch("document:firstdoc")).toBeUndefined();
+    expect(assertionStringToCheckWatch("document:firstdoc#view")).toBeUndefined();
+    expect(assertionStringToCheckWatch("#view@user:fred")).toBeUndefined();
+  });
+});

--- a/src/services/check.ts
+++ b/src/services/check.ts
@@ -64,7 +64,20 @@ export interface LiveCheckService {
 
   items: LiveCheckItem[];
 
+  /**
+   * recentlyAddedItemId is the id of the most recently added watch via
+   * addWatch. The UI uses it to drive a one-shot highlight animation; it
+   * auto-clears shortly after being set.
+   */
+  recentlyAddedItemId: string | null;
+
   addItem: () => void;
+  /**
+   * addWatch appends a CheckWatch as a new item and returns its id. The new
+   * id is also exposed via recentlyAddedItemId so consumers can flash a
+   * highlight on the row.
+   */
+  addWatch: (watch: CheckWatch) => string;
   itemUpdated: (item: LiveCheckItem) => void;
   removeItem: (item: LiveCheckItem) => void;
   loadWatches: (watches: CheckWatch[]) => void;
@@ -82,6 +95,45 @@ export function liveCheckItemToWatch(item: LiveCheckItem): CheckWatch {
     subject: item.subject,
     context: item.context,
   };
+}
+
+/**
+ * assertionStringToCheckWatch parses a relationship-style assertion string
+ * (`object#action@subject[caveat:context]`) into a CheckWatch. Returns
+ * undefined if the string does not split into the expected pieces.
+ *
+ * The split is structural (not semantic): we don't validate identifiers here,
+ * we just match the shape the assertions YAML actually uses. The Live Check
+ * service will surface any deeper invalidity once the watch is run.
+ */
+export function assertionStringToCheckWatch(value: string): CheckWatch | undefined {
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+
+  const hashIndex = trimmed.indexOf("#");
+  const atIndex = trimmed.indexOf("@", hashIndex + 1);
+  if (hashIndex < 0 || atIndex < 0) return undefined;
+
+  const object = trimmed.slice(0, hashIndex).trim();
+  const action = trimmed.slice(hashIndex + 1, atIndex).trim();
+  let subjectAndCaveat = trimmed.slice(atIndex + 1).trim();
+  if (!object || !action || !subjectAndCaveat) return undefined;
+
+  let context = "";
+  const caveatStart = subjectAndCaveat.indexOf("[");
+  if (caveatStart >= 0 && subjectAndCaveat.endsWith("]")) {
+    context = subjectAndCaveat.slice(caveatStart + 1, -1).trim();
+    subjectAndCaveat = subjectAndCaveat.slice(0, caveatStart).trim();
+  }
+
+  // The Live Check UI represents an unqualified subject without the trailing
+  // `#...`. Strip it here so the watch round-trips cleanly.
+  const subject = subjectAndCaveat.endsWith("#...")
+    ? subjectAndCaveat.slice(0, -"#...".length)
+    : subjectAndCaveat;
+  if (!subject) return undefined;
+
+  return { object, action, subject, context };
 }
 
 function liveCheckItemToString(item: LiveCheckItem): string {
@@ -187,6 +239,7 @@ export function useLiveCheckService(
   const [state, setState] = useState<LiveCheckRunState>({
     status: LiveCheckStatus.NEVER_RUN,
   });
+  const [recentlyAddedItemId, setRecentlyAddedItemId] = useState<string | null>(null);
 
   const devServiceStatus = developerService.state.status;
   const runCheck = useCallback(
@@ -273,6 +326,37 @@ export function useLiveCheckService(
     });
   }, []);
 
+  const addWatch = useCallback(
+    (watch: CheckWatch): string => {
+      const id = uuidv4();
+      const newItem: LiveCheckItem = {
+        id,
+        object: watch.object,
+        action: watch.action,
+        subject: watch.subject,
+        context: watch.context ?? "",
+        status: LiveCheckItemStatus.NOT_CHECKED,
+        errorMessage: undefined,
+      };
+      setItems((oldItems) => {
+        const next = [...oldItems, newItem];
+        // The datastore-listener effect only fires the check on datastore
+        // changes; an explicit kick is required so the new watch resolves
+        // without waiting for the next edit.
+        check(next);
+        return next;
+      });
+      setRecentlyAddedItemId(id);
+      // Clear the highlight id after the CSS animation completes (~1s plus a
+      // small buffer) so a subsequent add re-triggers the animation.
+      setTimeout(() => {
+        setRecentlyAddedItemId((current) => (current === id ? null : current));
+      }, 1200);
+      return id;
+    },
+    [check],
+  );
+
   const itemUpdated = useCallback(() => {
     // NOTE: this copies here because the code that
     // interacts with the items is mutating them directly.
@@ -311,8 +395,10 @@ export function useLiveCheckService(
     () => ({
       items: items,
       state: state,
+      recentlyAddedItemId: recentlyAddedItemId,
 
       addItem,
+      addWatch,
       itemUpdated,
       removeItem,
       loadWatches,
@@ -320,6 +406,6 @@ export function useLiveCheckService(
         setItems([]);
       },
     }),
-    [items, state, loadWatches, itemUpdated, addItem, removeItem],
+    [items, state, recentlyAddedItemId, loadWatches, itemUpdated, addItem, addWatch, removeItem],
   );
 }


### PR DESCRIPTION
Surface failing assertions in two places that let the user lift them into a Check Watch row with one click: a CodeLens above the assertion line in the YAML editor, and an "Add check watch" button on the assertion's row in the Problems panel. Clicking either opens the Check Watches drawer, runs the watch immediately, and flashes the new row so it's locatable.

Assertion-source errors are also re-routed from the Validation group to the Assertions group in the Problems panel, where they belong.

<img width="411" height="153" alt="Screenshot 2026-05-19 at 1 17 33 PM" src="https://github.com/user-attachments/assets/a33f7d40-fff6-44be-b7cf-1b32be44bf1e" />

