### PR TITLE
feat: add dismissible announcement bar (AuthZed Cloud promo)

### DIFF
--- a/src/components/FullPlayground.tsx
+++ b/src/components/FullPlayground.tsx
@@ -20,6 +20,7 @@ import { useEffect, useRef, useState, useMemo, type ComponentProps, type ReactNo
 import sjcl from "sjcl";
 import { toast } from "sonner";
 
+import { AnnouncementBar } from "@/components/announcement-bar";
 import { AuthSlot } from "@/components/auth-slot";
 import { BreadcrumbPill } from "@/components/breadcrumb-pill";
 import { ThemeToggle } from "@/components/theme-toggle";
@@ -641,6 +642,17 @@ export function ThemedAppView(props: {
 
   return (
     <div className="isolate flex h-screen w-screen flex-col overflow-hidden">
+      <AnnouncementBar contentId="ai-search-launch">
+        New: AI-powered search is now live.{" "}
+        <a
+          href="https://authzed.com/blog"
+          target="_blank"
+          rel="noreferrer"
+          className="font-medium underline underline-offset-4"
+        >
+          Learn more →
+        </a>
+      </AnnouncementBar>
       <DiscardConfirmationDialog
         open={confirmLoadExample}
         setOpen={setConfirmLoadExample}

--- a/src/components/FullPlayground.tsx
+++ b/src/components/FullPlayground.tsx
@@ -642,15 +642,15 @@ export function ThemedAppView(props: {
 
   return (
     <div className="isolate flex h-screen w-screen flex-col overflow-hidden">
-      <AnnouncementBar contentId="ai-search-launch">
-        New: AI-powered search is now live.{" "}
+      <AnnouncementBar contentId="authzed-cloud">
+        Deploy fully managed SpiceDB clusters on AuthZed Cloud.{" "}
         <a
-          href="https://authzed.com/blog"
+          href="https://authzed.com/cloud/signup?utm_source=playground&utm_medium=announcement_bar&utm_campaign=authzed_cloud"
           target="_blank"
           rel="noreferrer"
           className="font-medium underline underline-offset-4"
         >
-          Learn more →
+          Try now →
         </a>
       </AnnouncementBar>
       <DiscardConfirmationDialog

--- a/src/components/announcement-bar.tsx
+++ b/src/components/announcement-bar.tsx
@@ -94,7 +94,12 @@ export function AnnouncementBar({
         )}
       </div>
       {reserveSpace && (
-        <div data-slot="announcement-bar-spacer" aria-hidden="true" style={{ height }} />
+        <div
+          data-slot="announcement-bar-spacer"
+          aria-hidden="true"
+          className="shrink-0"
+          style={{ height }}
+        />
       )}
     </>
   );

--- a/src/components/announcement-bar.tsx
+++ b/src/components/announcement-bar.tsx
@@ -1,0 +1,101 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import { X } from "lucide-react";
+import * as React from "react";
+
+import { Button } from "@/components/ui/button";
+import { useDismissible } from "@/hooks/use-dismissible";
+import { cn } from "@/lib/utils";
+
+const announcementBarVariants = cva(
+  "fixed inset-x-0 top-0 z-50 flex w-full items-center justify-center px-10 py-2 text-center text-sm",
+  {
+    variants: {
+      variant: {
+        default: "bg-foreground text-background",
+        brand: "bg-primary text-primary-foreground",
+        info: "bg-secondary text-secondary-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+export type AnnouncementBarProps = React.ComponentProps<"div"> &
+  VariantProps<typeof announcementBarVariants> & {
+    /** Identifies the content shown (not a DOM id). Bump to re-show after dismissal. */
+    contentId: string;
+    /** Show the close button. Defaults to true. */
+    dismissible?: boolean;
+    /** Reserve layout space so the fixed bar never overlaps content. Defaults to true. */
+    reserveSpace?: boolean;
+    onDismiss?: () => void;
+  };
+
+export function AnnouncementBar({
+  contentId,
+  children,
+  variant = "default",
+  dismissible = true,
+  reserveSpace = true,
+  onDismiss,
+  className,
+  ...props
+}: AnnouncementBarProps) {
+  const { dismissed, dismiss } = useDismissible(contentId);
+  const barRef = React.useRef<HTMLDivElement>(null);
+  const [height, setHeight] = React.useState(0);
+
+  // Match the spacer to the fixed bar's height (tracks responsive wrapping).
+  // useLayoutEffect runs before paint, so the reserved space is set with no flash.
+  React.useLayoutEffect(() => {
+    const el = barRef.current;
+    if (!el || dismissed || !reserveSpace) {
+      setHeight(0);
+      return;
+    }
+    setHeight(el.offsetHeight);
+    const observer = new ResizeObserver(() => setHeight(el.offsetHeight));
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [dismissed, reserveSpace]);
+
+  if (dismissed) return null;
+
+  const handleDismiss = () => {
+    dismiss();
+    onDismiss?.();
+  };
+
+  return (
+    <>
+      <div
+        ref={barRef}
+        role="region"
+        aria-label="Announcement"
+        data-slot="announcement-bar"
+        data-variant={variant}
+        className={cn(announcementBarVariants({ variant }), className)}
+        {...props}
+      >
+        <div className="mx-auto">{children}</div>
+        {dismissible && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            aria-label="Dismiss announcement"
+            onClick={handleDismiss}
+            className="absolute right-1.5 top-1/2 -translate-y-1/2 text-current opacity-70 hover:bg-current/10 hover:text-current hover:opacity-100"
+          >
+            <X />
+          </Button>
+        )}
+      </div>
+      {reserveSpace && (
+        <div data-slot="announcement-bar-spacer" aria-hidden="true" style={{ height }} />
+      )}
+    </>
+  );
+}

--- a/src/components/announcement-bar.tsx
+++ b/src/components/announcement-bar.tsx
@@ -11,7 +11,7 @@ const announcementBarVariants = cva(
   {
     variants: {
       variant: {
-        default: "bg-foreground text-background",
+        default: "bg-foreground text-background dark:bg-secondary dark:text-secondary-foreground",
         brand: "bg-primary text-primary-foreground",
         info: "bg-secondary text-secondary-foreground",
       },

--- a/src/hooks/use-dismissible.ts
+++ b/src/hooks/use-dismissible.ts
@@ -37,7 +37,8 @@ export function useDismissible(
 ): UseDismissibleResult {
   const [ids, setIds] = useState<string[]>(() => readDismissed(storageKey));
 
-  // Keep multiple tabs consistent.
+  // Sync dismissal across other tabs (the `storage` event fires only in
+  // documents other than the one that wrote the value, not same-tab).
   useEffect(() => {
     function onStorage(event: StorageEvent) {
       if (event.key === storageKey) {

--- a/src/hooks/use-dismissible.ts
+++ b/src/hooks/use-dismissible.ts
@@ -1,0 +1,70 @@
+import { useCallback, useEffect, useState } from "react";
+
+const DEFAULT_STORAGE_KEY = "announcement-bar:dismissed";
+
+function readDismissed(storageKey: string): string[] {
+  try {
+    const raw = localStorage.getItem(storageKey);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter((v): v is string => typeof v === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeDismissed(storageKey: string, ids: string[]): void {
+  try {
+    localStorage.setItem(storageKey, JSON.stringify(ids));
+  } catch {
+    // Ignore private-mode / quota errors.
+  }
+}
+
+export type UseDismissibleResult = {
+  dismissed: boolean;
+  dismiss: () => void;
+  reset: () => void;
+};
+
+/**
+ * Remembers, in localStorage, whether the thing identified by `id` has been
+ * dismissed. Generic: AnnouncementBar passes its `contentId` as `id`.
+ */
+export function useDismissible(
+  id: string,
+  storageKey: string = DEFAULT_STORAGE_KEY,
+): UseDismissibleResult {
+  const [ids, setIds] = useState<string[]>(() => readDismissed(storageKey));
+
+  // Keep multiple tabs consistent.
+  useEffect(() => {
+    function onStorage(event: StorageEvent) {
+      if (event.key === storageKey) {
+        setIds(readDismissed(storageKey));
+      }
+    }
+    window.addEventListener("storage", onStorage);
+    return () => window.removeEventListener("storage", onStorage);
+  }, [storageKey]);
+
+  const dismiss = useCallback(() => {
+    setIds((prev) => {
+      if (prev.includes(id)) return prev;
+      const next = [...prev, id];
+      writeDismissed(storageKey, next);
+      return next;
+    });
+  }, [id, storageKey]);
+
+  const reset = useCallback(() => {
+    setIds((prev) => {
+      if (!prev.includes(id)) return prev;
+      const next = prev.filter((v) => v !== id);
+      writeDismissed(storageKey, next);
+      return next;
+    });
+  }, [id, storageKey]);
+
+  return { dismissed: ids.includes(id), dismiss, reset };
+}

--- a/src/tests/browser/announcement-bar.test.tsx
+++ b/src/tests/browser/announcement-bar.test.tsx
@@ -49,7 +49,7 @@ describe("AnnouncementBar", () => {
     const withSpacer = await render(<AnnouncementBar contentId="t5">With spacer</AnnouncementBar>);
     await expect.element(withSpacer.getByText("With spacer")).toBeVisible();
     expect(document.querySelector('[data-slot="announcement-bar-spacer"]')).not.toBeNull();
-    void withSpacer.unmount();
+    await withSpacer.unmount();
 
     const noSpacer = await render(
       <AnnouncementBar contentId="t6" reserveSpace={false}>

--- a/src/tests/browser/announcement-bar.test.tsx
+++ b/src/tests/browser/announcement-bar.test.tsx
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+
+import { AnnouncementBar } from "@/components/announcement-bar";
+
+const KEY = "announcement-bar:dismissed";
+
+describe("AnnouncementBar", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("renders its children", async () => {
+    const screen = await render(
+      <AnnouncementBar contentId="t1">Hello announcement</AnnouncementBar>,
+    );
+    await expect.element(screen.getByText("Hello announcement")).toBeVisible();
+  });
+
+  it("dismiss hides the bar, persists, and calls onDismiss", async () => {
+    const onDismiss = vi.fn();
+    const screen = await render(
+      <AnnouncementBar contentId="t2" onDismiss={onDismiss}>
+        Bye
+      </AnnouncementBar>,
+    );
+    await screen.getByRole("button", { name: "Dismiss announcement" }).click();
+    await expect.element(screen.getByText("Bye")).not.toBeInTheDocument();
+    expect(onDismiss).toHaveBeenCalledOnce();
+    expect(JSON.parse(localStorage.getItem(KEY)!)).toContain("t2");
+  });
+
+  it("renders nothing for an already-dismissed contentId", async () => {
+    localStorage.setItem(KEY, JSON.stringify(["t3"]));
+    const screen = await render(<AnnouncementBar contentId="t3">Should not show</AnnouncementBar>);
+    await expect.element(screen.getByText("Should not show")).not.toBeInTheDocument();
+  });
+
+  it("applies the selected variant", async () => {
+    const screen = await render(
+      <AnnouncementBar contentId="t4" variant="brand">
+        Branded
+      </AnnouncementBar>,
+    );
+    await expect
+      .element(screen.getByRole("region", { name: "Announcement" }))
+      .toHaveAttribute("data-variant", "brand");
+  });
+
+  it("includes the spacer by default and omits it when reserveSpace is false", async () => {
+    const withSpacer = await render(<AnnouncementBar contentId="t5">With spacer</AnnouncementBar>);
+    await expect.element(withSpacer.getByText("With spacer")).toBeVisible();
+    expect(document.querySelector('[data-slot="announcement-bar-spacer"]')).not.toBeNull();
+    void withSpacer.unmount();
+
+    const noSpacer = await render(
+      <AnnouncementBar contentId="t6" reserveSpace={false}>
+        No spacer
+      </AnnouncementBar>,
+    );
+    await expect.element(noSpacer.getByText("No spacer")).toBeVisible();
+    expect(document.querySelector('[data-slot="announcement-bar-spacer"]')).toBeNull();
+  });
+
+  it("hides the close button when dismissible is false", async () => {
+    const screen = await render(
+      <AnnouncementBar contentId="t7" dismissible={false}>
+        No close
+      </AnnouncementBar>,
+    );
+    await expect.element(screen.getByText("No close")).toBeVisible();
+    expect(document.querySelector('button[aria-label="Dismiss announcement"]')).toBeNull();
+  });
+});

--- a/src/tests/browser/announcement-integration.test.tsx
+++ b/src/tests/browser/announcement-integration.test.tsx
@@ -1,0 +1,15 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { mountPlayground } from "./helpers";
+
+describe("FullPlayground announcement bar", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("shows the announcement region and dismisses it", async () => {
+    const screen = await mountPlayground();
+    const region = screen.getByRole("region", { name: "Announcement" });
+    await expect.element(region).toBeVisible();
+    await screen.getByRole("button", { name: "Dismiss announcement" }).click();
+    await expect.element(region).not.toBeInTheDocument();
+  });
+});

--- a/src/tests/browser/use-dismissible.test.tsx
+++ b/src/tests/browser/use-dismissible.test.tsx
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { render } from "vitest-browser-react";
+
+import { useDismissible } from "@/hooks/use-dismissible";
+
+const KEY = "announcement-bar:dismissed";
+
+function Harness({ id }: { id: string }) {
+  const { dismissed, dismiss, reset } = useDismissible(id);
+  return (
+    <div>
+      <span data-testid="state">{dismissed ? "dismissed" : "visible"}</span>
+      <button type="button" onClick={dismiss}>
+        dismiss
+      </button>
+      <button type="button" onClick={reset}>
+        reset
+      </button>
+    </div>
+  );
+}
+
+describe("useDismissible", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("starts visible for a new id", async () => {
+    const screen = await render(<Harness id="a" />);
+    await expect.element(screen.getByTestId("state")).toHaveTextContent("visible");
+  });
+
+  it("dismiss() flips state and persists the id", async () => {
+    const screen = await render(<Harness id="a" />);
+    await screen.getByRole("button", { name: "dismiss" }).click();
+    await expect.element(screen.getByTestId("state")).toHaveTextContent("dismissed");
+    expect(JSON.parse(localStorage.getItem(KEY)!)).toContain("a");
+  });
+
+  it("a different id still shows after another was dismissed", async () => {
+    localStorage.setItem(KEY, JSON.stringify(["a"]));
+    const screen = await render(<Harness id="b" />);
+    await expect.element(screen.getByTestId("state")).toHaveTextContent("visible");
+  });
+
+  it("reset() clears the id", async () => {
+    localStorage.setItem(KEY, JSON.stringify(["a"]));
+    const screen = await render(<Harness id="a" />);
+    await expect.element(screen.getByTestId("state")).toHaveTextContent("dismissed");
+    await screen.getByRole("button", { name: "reset" }).click();
+    await expect.element(screen.getByTestId("state")).toHaveTextContent("visible");
+    expect(JSON.parse(localStorage.getItem(KEY)!)).not.toContain("a");
+  });
+
+  it("handles corrupt storage without throwing", async () => {
+    localStorage.setItem(KEY, "{not json");
+    const screen = await render(<Harness id="a" />);
+    await expect.element(screen.getByTestId("state")).toHaveTextContent("visible");
+  });
+});


### PR DESCRIPTION
## Summary

Adds a reusable, theme-compatible announcement bar fixed to the top of the window and wires it into the playground. It currently promotes **AuthZed Cloud**.

The bar is dismissible, and dismissal is remembered **per content version** — bump `contentId` and the bar re-shows for everyone who dismissed the previous message.

<img width="1214" height="318" alt="image" src="https://github.com/user-attachments/assets/7a1dc40d-38ec-46e5-b016-f7224c795be8" />

## What's included

- **`useDismissible(id, storageKey?)`** (`src/hooks/use-dismissible.ts`) — generic localStorage-backed dismissal memory. Reads synchronously in the state initializer (no flash-of-dismissed-content), guards all storage access in try/catch (private mode / corrupt JSON safe), and syncs across tabs via the `storage` event.
- **`<AnnouncementBar>`** (`src/components/announcement-bar.tsx`) — `position: fixed` full-width bar plus an in-flow spacer whose height tracks the bar via `ResizeObserver`, so it never overlaps page content and adapts to responsive wrapping. `cva` variants (`default` / `brand` / `info`) built on semantic theme tokens; shadcn `Button` + lucide `X` close control. Content can be text or any component.
  - `default` variant renders a dark bar in both themes: `bg-foreground` / `text-background` in light mode and `bg-secondary` / `text-secondary-foreground` (the dark-grey surface token) in dark mode.
- **Playground integration** (`src/components/FullPlayground.tsx`) — mounted as the first flex child of the root layout; the spacer pushes the existing chrome down. Only `FullPlayground` is wired (Inline/Embedded iframe modes are untouched). The link targets the AuthZed Cloud signup with UTM params (`utm_source=playground`).

## Usage

```tsx
<AnnouncementBar contentId="authzed-cloud" variant="default">
  Deploy fully managed SpiceDB clusters on AuthZed Cloud. <a href="…">Try now →</a>
</AnnouncementBar>
```

## Test plan

- New tests (Vitest browser project, real DOM + localStorage, not mocks):
  - `use-dismissible.test.tsx` — new id shows; dismiss persists + flips state; a different id still shows; reset clears; corrupt storage handled.
  - `announcement-bar.test.tsx` — renders children; dismiss hides + persists + calls `onDismiss`; pre-dismissed `contentId` renders nothing; variant applied; spacer present/absent per `reserveSpace`; close hidden when `dismissible={false}`.
  - `announcement-integration.test.tsx` — the bar shows in the playground and dismisses (stable role/aria-label selectors).
- Full suite green: unit 78/78, browser 24/24 (pristine output).
- `pnpm lint` 0 errors, `tsc --noEmit` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
