### PR TITLE
feat: add ?fresh URL to open a clean playground

### DIFF
--- a/src/components/FullPlayground.tsx
+++ b/src/components/FullPlayground.tsx
@@ -120,21 +120,24 @@ enum SharingStatus {
 }
 
 export function FullPlayground() {
+  const fresh = new URLSearchParams(window.location.search).has("fresh");
   return (
     <>
       <DiscordChatCrate
         serverId={AppConfig().discord.serverId}
         channelId={AppConfig().discord.channelId}
       />
-      <ApolloedPlayground />
+      <ApolloedPlayground fresh={fresh} />
     </>
   );
 }
 
-function ApolloedPlayground() {
-  const datastore = usePlaygroundDatastore();
+function ApolloedPlayground({ fresh }: { fresh?: boolean }) {
+  const datastore = usePlaygroundDatastore(fresh);
   const developerService = useDeveloperService();
-  const liveCheckService = useLiveCheckService(developerService, datastore, { persist: true });
+  // In fresh mode, do not persist (or load) check watches either, so no saved
+  // playground state is exposed while screen sharing.
+  const liveCheckService = useLiveCheckService(developerService, datastore, { persist: !fresh });
   return (
     <ThemedAppView
       datastore={datastore}

--- a/src/services/datastore.test.ts
+++ b/src/services/datastore.test.ts
@@ -48,3 +48,16 @@ describe("DataStore baseline tracking", () => {
     expect(store.computeContentHash()).not.toBe(before);
   });
 });
+
+describe("EphemeralDataStore isolation", () => {
+  it("editing one store does not leak into a freshly constructed store", () => {
+    const first = new EphemeralDataStore();
+    const item = first.getSingletonByKind(DataStoreItemKind.SCHEMA);
+    first.update(item, "definition leaked {}");
+
+    const second = new EphemeralDataStore();
+    expect(second.getSingletonByKind(DataStoreItemKind.SCHEMA).editableContents).not.toContain(
+      "leaked",
+    );
+  });
+});

--- a/src/services/datastore.ts
+++ b/src/services/datastore.ts
@@ -338,7 +338,10 @@ class LocalStorageDataStore extends DataStore {
 }
 
 export class EphemeralDataStore extends DataStore {
-  private data: DataStorageData = EMPTY_STORE;
+  // Deep clone rather than referencing the module-level EMPTY_STORE: update()
+  // mutates the stored object in place, so sharing the reference would corrupt
+  // the default sample for every other store that falls back to EMPTY_STORE.
+  private data: DataStorageData = JSON.parse(JSON.stringify(EMPTY_STORE));
   private wasEdited: boolean = false;
 
   getStored(): DataStorageData {

--- a/src/services/datastore.ts
+++ b/src/services/datastore.ts
@@ -376,7 +376,12 @@ export function useReadonlyDatastore(): DataStore {
  * persisted state (useful for screen sharing).
  */
 export function usePlaygroundDatastore(fresh?: boolean): DataStore {
-  const ephemeralRef = useRef(new EphemeralDataStore());
-  const localRef = useRef(new LocalStorageDataStore());
-  return fresh ? ephemeralRef.current : localRef.current;
+  // Only the selected store is instantiated. Constructing LocalStorageDataStore
+  // in fresh mode is avoided so a fresh session never touches local storage, and
+  // lazy refs avoid allocating a throwaway instance on every render.
+  const storeRef = useRef<DataStore | null>(null);
+  if (storeRef.current === null) {
+    storeRef.current = fresh ? new EphemeralDataStore() : new LocalStorageDataStore();
+  }
+  return storeRef.current;
 }

--- a/src/services/datastore.ts
+++ b/src/services/datastore.ts
@@ -372,8 +372,11 @@ export function useReadonlyDatastore(): DataStore {
 /**
  * usePlaygroundDatastore returns a hook for interacting with the backing datastore
  * for the playground. Data is retrieved and stored in local storage.
+ * When fresh is true, an ephemeral datastore is used instead, avoiding any
+ * persisted state (useful for screen sharing).
  */
-export function usePlaygroundDatastore(): DataStore {
-  const datastoreRef = useRef(new LocalStorageDataStore());
-  return datastoreRef.current;
+export function usePlaygroundDatastore(fresh?: boolean): DataStore {
+  const ephemeralRef = useRef(new EphemeralDataStore());
+  const localRef = useRef(new LocalStorageDataStore());
+  return fresh ? ephemeralRef.current : localRef.current;
 }


### PR DESCRIPTION
Fixes #26.

Adds a `?fresh` URL param that opens the playground with no saved schema/relationships/check-watches loaded — for screen-sharing without exposing saved work. In fresh mode it uses an ephemeral (non-persisted) datastore and disables check-watch persistence; normal sessions are unchanged and saved state is never overwritten.

Verified live: on `main`, `/?fresh` still shows saved work (param ignored); on this branch it shows the pristine default and does not clobber saved state.

**Open question:** `?fresh` is a URL param with no UI affordance — you have to know to type it. The issue asks for "a dedicated URL or option." Should we also add a header button / menu item (e.g. "New fresh playground") for discoverability? Easy to add on top of this; happy to follow up if wanted.
