### PR TITLE
Fix tab-strip overflow onto assistant dock; raise AI function timeout to 180s

### DIFF
--- a/src/components/editor-groups/EditorGroup.tsx
+++ b/src/components/editor-groups/EditorGroup.tsx
@@ -97,35 +97,38 @@ export function EditorGroup({
   return (
     <div className={cn("flex flex-col h-full", className)}>
       {/* Tab strip */}
-      <div
-        className="relative flex shrink-0 items-stretch bg-chrome-tabbar"
-        onDragOver={handleStripDragOver}
-        onDragLeave={handleDragLeave}
-        onDrop={handleDrop}
-      >
-        {group.tabs.map((tab, i) => (
-          <React.Fragment key={tab}>
-            {dropIndicator?.index === i && <DropMarker />}
-            <TabContextMenu tab={tab} groupId={group.id} canClose={canCloseTabs}>
-              <EditorTab
-                document={tab}
-                active={tab === group.activeTab}
-                canClose={canCloseTabs}
-                diagnostics={tabDiagnostics?.[tab]}
-                onClick={() => setActiveTab(group.id, tab)}
-                onClose={() => closeTab(tab)}
-                onDragStart={(e) => handleDragStart(e, tab)}
-                onDragOver={(e) => handleTabDragOver(e, tab)}
-                onDrop={handleDrop}
-              />
-            </TabContextMenu>
-          </React.Fragment>
-        ))}
-        {dropIndicator?.index === group.tabs.length && <DropMarker />}
-        <div className="ml-1 flex items-center">
-          <OpenDocumentMenu groupId={group.id} />
+      <div className="flex shrink-0 items-stretch bg-chrome-tabbar">
+        <div
+          className="relative flex min-w-0 flex-1 items-stretch overflow-x-auto"
+          onDragOver={handleStripDragOver}
+          onDragLeave={handleDragLeave}
+          onDrop={handleDrop}
+        >
+          {group.tabs.map((tab, i) => (
+            <React.Fragment key={tab}>
+              {dropIndicator?.index === i && <DropMarker />}
+              <TabContextMenu tab={tab} groupId={group.id} canClose={canCloseTabs}>
+                <EditorTab
+                  document={tab}
+                  active={tab === group.activeTab}
+                  canClose={canCloseTabs}
+                  diagnostics={tabDiagnostics?.[tab]}
+                  onClick={() => setActiveTab(group.id, tab)}
+                  onClose={() => closeTab(tab)}
+                  onDragStart={(e) => handleDragStart(e, tab)}
+                  onDragOver={(e) => handleTabDragOver(e, tab)}
+                  onDrop={handleDrop}
+                  className="shrink-0 whitespace-nowrap"
+                />
+              </TabContextMenu>
+            </React.Fragment>
+          ))}
+          {dropIndicator?.index === group.tabs.length && <DropMarker />}
+          <div className="ml-1 flex shrink-0 items-center">
+            <OpenDocumentMenu groupId={group.id} />
+          </div>
         </div>
-        <div className="ml-auto flex items-center pr-1">
+        <div className="ml-auto flex shrink-0 items-center pr-1">
           <SplitMenu tab={group.activeTab} />
           {closable && (
             <Tooltip>

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "functions": {
     "api/ai.ts": {
-      "maxDuration": 60
+      "maxDuration": 180
     }
   },
   "headers": [


### PR DESCRIPTION
## Summary
- Fix the editor tab strip (Schema/Relationships/Assertions/Expected Relations) bleeding visually on top of the Assistant/History dock on narrow screens. A stray `position: relative` with no overflow containment promoted the tab strip into a positioned paint layer, so its overflow rendered over the dock instead of behind it. Tabs now scroll horizontally instead of wrapping/overflowing.
- Raise `api/ai.ts`'s Vercel `maxDuration` from 60s to 180s.

## Test plan
- [x] Reproduced the original overlap in a live browser at 900x700 (matches reported screenshot) and confirmed it's gone after the fix
- [x] Verified at 500px, 900px, and 1600px viewports — tabs scroll cleanly, no overlap, full-width layout unchanged
- [x] Tab click/switch and split-view still function correctly
- [x] `pnpm test:unit` and `pnpm test:browser` pass
- [x] `tsc --noEmit` and `oxlint` clean on changed files
- [ ] Confirm target Vercel plan supports a 180s maxDuration (Hobby caps at 60s)