### PR TITLE
Assistant debug/fix affordances for errors and failing checks

### DIFF
--- a/src/components/EditorDisplay.tsx
+++ b/src/components/EditorDisplay.tsx
@@ -10,7 +10,10 @@ import { flushSync } from "react-dom";
 import { useSettings } from "@/components/SettingsProvider";
 import { useResolvedTheme } from "@/hooks/use-resolved-theme";
 
+import { buildErrorPrompt, type ErrorPromptInput } from "../services/assistant/debugPrompts";
+import { requestAssistantDebug } from "../services/assistant/debugRequest";
 import { assertionStringToCheckWatch, CheckWatch, LiveCheckService } from "../services/check";
+import AppConfig from "../services/configservice";
 import { ScrollLocation, useCookieService } from "../services/cookieservice";
 import { DataStore, DataStoreItem, DataStoreItemKind } from "../services/datastore";
 import { LocalParseState } from "../services/localparse";
@@ -47,6 +50,14 @@ const latestLocalParseStateRef: { current: LocalParseState | null } = { current:
 const latestLiveCheckServiceRef: { current: LiveCheckService | null } = { current: null };
 
 const ADD_CHECK_WATCH_COMMAND_ID = "playground.addCheckWatchFromAssertion";
+
+const ASK_ASSISTANT_DEBUG_COMMAND_ID = "playground.askAssistantDebug";
+
+// Maps each editor model's URI to the datastore kind it displays, so the
+// module-scope assistant-debug CodeLens provider (which only receives a model)
+// can restrict itself to the schema and assertions documents and label the
+// prompt's error source correctly.
+const modelKindByUri = new Map<string, DataStoreItemKind>();
 
 export type EditorDisplayProps = {
   datastore: DataStore;
@@ -418,6 +429,7 @@ export function EditorDisplay(props: EditorDisplayProps) {
       registerDSLanguage(monacoInstance);
       registerTupleLanguage(monacoInstance, () => latestLocalParseStateRef.current!);
       registerAssertionFixes(monacoInstance);
+      registerAssistantDebugLenses(monacoInstance);
       languagesRegistered = true;
       // Themes are defined inside registerDSLanguage. The Editor already rendered
       // with the theme prop before defineTheme ran, so Monaco fell back to its
@@ -430,6 +442,9 @@ export function EditorDisplay(props: EditorDisplayProps) {
         ...editorRefs.current,
         [itemId]: editor,
       };
+
+      const model = editor.getModel();
+      if (model) modelKindByUri.set(model.uri.toString(), currentItem.kind);
 
       editor.onDidChangeCursorPosition((e: monaco.editor.ICursorPositionChangedEvent) => {
         debouncedSetEditorPosition(e.position);
@@ -453,6 +468,7 @@ export function EditorDisplay(props: EditorDisplayProps) {
         }
         resizeObserversRef.current[itemId]?.disconnect();
         delete resizeObserversRef.current[itemId];
+        if (model) modelKindByUri.delete(model.uri.toString());
       });
 
       updateMarkers();
@@ -744,4 +760,76 @@ function registerAssertionFixes(monacoInstance: typeof monaco) {
   };
   codeLensProviderRef.current = codeLensProvider;
   monacoInstance.languages.registerCodeLensProvider("yaml", codeLensProvider);
+}
+
+/**
+ * registerAssistantDebugLenses wires an "Ask assistant to fix" CodeLens above
+ * each error marker in the schema and assertions editors. Clicking it opens the
+ * assistant and auto-submits a prompt describing that specific error. Mirrors
+ * registerAssertionFixes (registered once at module scope, refreshed on marker
+ * changes). Gated on AppConfig().aiEnabled so nothing appears when AI is off.
+ *
+ * Markers in each editor are already source-scoped by updateMarkers (the schema
+ * editor only shows SCHEMA-source errors; the assertions editor only
+ * ASSERTION-source), so we key the error source off the model's datastore kind
+ * via modelKindByUri and restrict to the schema + assertions documents.
+ */
+function registerAssistantDebugLenses(monacoInstance: typeof monaco) {
+  monacoInstance.editor.registerCommand(
+    ASK_ASSISTANT_DEBUG_COMMAND_ID,
+    (_accessor: unknown, arg: ErrorPromptInput) => {
+      requestAssistantDebug(buildErrorPrompt(arg), "editor");
+    },
+  );
+
+  const providerRef: { current: monaco.languages.CodeLensProvider | null } = { current: null };
+  const emitter = new monacoInstance.Emitter<monaco.languages.CodeLensProvider>();
+  monacoInstance.editor.onDidChangeMarkers(() => {
+    if (providerRef.current) emitter.fire(providerRef.current);
+  });
+
+  const provider: monaco.languages.CodeLensProvider = {
+    onDidChange: emitter.event,
+    provideCodeLenses: (model) => {
+      const empty = { lenses: [], dispose: () => undefined };
+      if (!AppConfig().aiEnabled) return empty;
+      const kind = modelKindByUri.get(model.uri.toString());
+      if (kind !== DataStoreItemKind.SCHEMA && kind !== DataStoreItemKind.ASSERTIONS) {
+        return empty;
+      }
+      const source =
+        kind === DataStoreItemKind.SCHEMA
+          ? DeveloperError_Source.SCHEMA
+          : DeveloperError_Source.ASSERTION;
+      const markers = monacoInstance.editor.getModelMarkers({ resource: model.uri });
+      const lenses: monaco.languages.CodeLens[] = [];
+      for (const marker of markers) {
+        if (marker.severity !== monacoInstance.MarkerSeverity.Error) continue;
+        const context = typeof marker.code === "string" ? marker.code : (marker.code?.value ?? "");
+        const arg: ErrorPromptInput = {
+          source,
+          line: marker.startLineNumber,
+          message: marker.message,
+          context,
+        };
+        lenses.push({
+          range: {
+            startLineNumber: marker.startLineNumber,
+            startColumn: 1,
+            endLineNumber: marker.startLineNumber,
+            endColumn: 1,
+          },
+          command: {
+            id: ASK_ASSISTANT_DEBUG_COMMAND_ID,
+            title: "$(lightbulb) Ask assistant to fix",
+            arguments: [arg],
+          },
+        });
+      }
+      return { lenses, dispose: () => undefined };
+    },
+  };
+  providerRef.current = provider;
+  monacoInstance.languages.registerCodeLensProvider(DS_LANGUAGE_NAME, provider);
+  monacoInstance.languages.registerCodeLensProvider("yaml", provider);
 }

--- a/src/components/panels/AskAssistantActions.tsx
+++ b/src/components/panels/AskAssistantActions.tsx
@@ -1,0 +1,72 @@
+import { Sparkles } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+
+import { buildCheckWatchPrompt, buildErrorPrompt } from "../../services/assistant/debugPrompts";
+import { requestAssistantDebug } from "../../services/assistant/debugRequest";
+import { LiveCheckItem } from "../../services/check";
+import { DeveloperError } from "../../spicedb-common/protodefs/developer/v1/developer_pb";
+
+/**
+ * AskAssistantFixAction is the per-error "Ask assistant to fix" button used in
+ * the Problems panel. Its parent renders it only when AI is enabled.
+ */
+export function AskAssistantFixAction({ error }: { error: DeveloperError }) {
+  const onClick = () =>
+    requestAssistantDebug(
+      buildErrorPrompt({
+        source: error.source,
+        line: error.line,
+        message: error.message,
+        context: error.context ?? "",
+      }),
+      "problems",
+    );
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button size="xs" variant="ghost" onClick={onClick}>
+          <Sparkles />
+          Ask assistant to fix
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>Have the assistant debug and fix this error</TooltipContent>
+    </Tooltip>
+  );
+}
+
+/**
+ * AskAssistantDebugButton is the per-watch "Ask assistant to debug" icon button
+ * used in the Watches panel. Its parent renders it only when AI is enabled and
+ * the watch is in a non-passing state (isDebuggableWatchStatus).
+ */
+export function AskAssistantDebugButton({ item }: { item: LiveCheckItem }) {
+  const onClick = () =>
+    requestAssistantDebug(
+      buildCheckWatchPrompt({
+        object: item.object,
+        action: item.action,
+        subject: item.subject,
+        context: item.context,
+        status: item.status,
+        errorMessage: item.errorMessage,
+      }),
+      "watches",
+    );
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          size="icon-sm"
+          variant="ghost"
+          aria-label="Ask assistant to debug"
+          onClick={onClick}
+        >
+          <Sparkles />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>Have the assistant debug and fix this check</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/src/components/panels/assistant/AssistantPanel.tsx
+++ b/src/components/panels/assistant/AssistantPanel.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { type DisplayMessage, useAssistantStore } from "../../../services/assistant/store";
 import type { HistoryRecorder } from "../../../services/assistant/types";
 import { useAssistantController } from "../../../services/assistant/useAssistantController";
+import { usePendingPromptConsumer } from "../../../services/assistant/usePendingPrompt";
 import type { DataStore } from "../../../services/datastore";
 import { useHistoryStore } from "../../../services/history/historyStore";
 import { restoreRevision } from "../../../services/history/useHistoryRecorder";
@@ -23,6 +24,9 @@ export function AssistantPanel({
   history: HistoryRecorder;
 }) {
   const { submit, stop } = useAssistantController(services, datastore, history);
+  // Drain any externally-requested debug prompt (inline "Ask assistant to fix"
+  // affordances) into a turn now that the panel is mounted.
+  usePendingPromptConsumer(submit);
   const display = useAssistantStore((s) => s.display);
   const status = useAssistantStore((s) => s.status);
   const reset = useAssistantStore((s) => s.reset);

--- a/src/components/panels/problems.tsx
+++ b/src/components/panels/problems.tsx
@@ -6,6 +6,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { cn } from "@/lib/utils";
 
 import { assertionStringToCheckWatch, LiveCheckService } from "../../services/check";
+import AppConfig from "../../services/configservice";
 import { Services } from "../../services/services";
 import {
   DeveloperError,
@@ -15,6 +16,7 @@ import {
 import { DocumentLink } from "../document-link";
 import { useDrawerStore } from "../drawer/state";
 
+import { AskAssistantFixAction } from "./AskAssistantActions";
 import { DeveloperSourceDisplay, DeveloperWarningSourceDisplay } from "./errordisplays";
 
 interface ProblemsPanelProps {
@@ -26,6 +28,7 @@ export function ProblemsPanel({ services }: ProblemsPanelProps) {
   const warnings = services.problemService.warnings;
   const invalidRels = services.problemService.invalidRelationships;
   const allValidationErrors = services.problemService.validationErrors;
+  const aiEnabled = AppConfig().aiEnabled;
 
   const schemaErrors = requestErrors.filter((e) => e.source === DeveloperError_Source.SCHEMA);
   const relationshipRequestErrors = requestErrors.filter(
@@ -46,7 +49,11 @@ export function ProblemsPanel({ services }: ProblemsPanelProps) {
     <div className="p-2 space-y-1">
       <Group title="Schema" errorCount={schemaErrors.length} warningCount={warnings.length}>
         {schemaErrors.map((de, i) => (
-          <ErrorRow key={`s${i}`} error={de} />
+          <ErrorRow
+            key={`s${i}`}
+            error={de}
+            action={aiEnabled ? <AskAssistantFixAction error={de} /> : undefined}
+          />
         ))}
         {warnings.map((dw, i) => (
           <WarningRow key={`w${i}`} warning={dw} />
@@ -78,7 +85,12 @@ export function ProblemsPanel({ services }: ProblemsPanelProps) {
           <ErrorRow
             key={`a${i}`}
             error={de}
-            action={<AddCheckWatchAction error={de} liveCheckService={services.liveCheckService} />}
+            action={
+              <div className="flex items-center gap-1">
+                <AddCheckWatchAction error={de} liveCheckService={services.liveCheckService} />
+                {aiEnabled && <AskAssistantFixAction error={de} />}
+              </div>
+            }
           />
         ))}
       </Group>
@@ -97,7 +109,11 @@ export function ProblemsPanel({ services }: ProblemsPanelProps) {
         }
       >
         {validationErrors.map((ve, i) => (
-          <ErrorRow key={`v${i}`} error={ve} />
+          <ErrorRow
+            key={`v${i}`}
+            error={ve}
+            action={aiEnabled ? <AskAssistantFixAction error={ve} /> : undefined}
+          />
         ))}
       </Group>
     </div>

--- a/src/components/panels/watches.tsx
+++ b/src/components/panels/watches.tsx
@@ -28,12 +28,14 @@ import {
   TableRow,
 } from "@/components/ui/table";
 
+import { isDebuggableWatchStatus } from "../../services/assistant/debugPrompts";
 import {
   LiveCheckItem,
   LiveCheckItemStatus,
   LiveCheckService,
   LiveCheckStatus,
 } from "../../services/check";
+import AppConfig from "../../services/configservice";
 import { DataStore, DataStoreItemKind } from "../../services/datastore";
 import { LocalParseService } from "../../services/localparse";
 import { Services } from "../../services/services";
@@ -41,6 +43,8 @@ import { parseRelationships } from "../../spicedb-common/parsing";
 import { RelationTuple as Relationship } from "../../spicedb-common/protodefs/core/v1/core_pb";
 import { CheckDebugTraceView } from "../CheckDebugTraceView";
 import { Alert, AlertTitle, AlertDescription } from "../ui/alert";
+
+import { AskAssistantDebugButton } from "./AskAssistantActions";
 
 interface WatchesPanelProps {
   services: Services;
@@ -315,10 +319,19 @@ function LiveCheckRow(props: LiveCheckRowProps) {
             className="font-mono placeholder:text-muted-foreground/50"
           />
         </TableCell>
-        <TableCell className="w-8">
-          <Button size="icon-sm" variant="ghost" onClick={() => liveCheckService.removeItem(item)}>
-            <Trash2 />
-          </Button>
+        <TableCell className="w-auto whitespace-nowrap">
+          <div className="flex items-center justify-end gap-1">
+            {AppConfig().aiEnabled && isDebuggableWatchStatus(item.status) && (
+              <AskAssistantDebugButton item={item} />
+            )}
+            <Button
+              size="icon-sm"
+              variant="ghost"
+              onClick={() => liveCheckService.removeItem(item)}
+            >
+              <Trash2 />
+            </Button>
+          </div>
         </TableCell>
       </TableRow>
       {item.debugInformation !== undefined && isExpanded && (

--- a/src/services/assistant/debugPrompts.test.ts
+++ b/src/services/assistant/debugPrompts.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+
+import { DeveloperError_Source } from "../../spicedb-common/protodefs/developer/v1/developer_pb";
+import { LiveCheckItemStatus } from "../check";
+
+import { buildCheckWatchPrompt, buildErrorPrompt, isDebuggableWatchStatus } from "./debugPrompts";
+
+describe("buildErrorPrompt", () => {
+  it("phrases a schema error with line and context", () => {
+    const p = buildErrorPrompt({
+      source: DeveloperError_Source.SCHEMA,
+      line: 4,
+      message: "expected type",
+      context: "viewer",
+    });
+    expect(p).toContain("schema");
+    expect(p).toContain("line 4");
+    expect(p).toContain("expected type");
+    expect(p).toContain("viewer");
+    expect(p.toLowerCase()).toContain("fix");
+  });
+
+  it("phrases an assertion failure using the assertion string in context", () => {
+    const p = buildErrorPrompt({
+      source: DeveloperError_Source.ASSERTION,
+      line: 0,
+      message: "expected allowed but got denied",
+      context: "document:budget#view@user:tim",
+    });
+    expect(p).toContain("assertion");
+    expect(p).toContain("document:budget#view@user:tim");
+    expect(p).toContain("expected allowed but got denied");
+  });
+
+  it("omits the line clause when line is 0", () => {
+    const p = buildErrorPrompt({
+      source: DeveloperError_Source.SCHEMA,
+      line: 0,
+      message: "boom",
+      context: "",
+    });
+    expect(p).not.toContain("line 0");
+  });
+
+  it("phrases a validation error", () => {
+    const p = buildErrorPrompt({
+      source: DeveloperError_Source.VALIDATION_YAML,
+      line: 3,
+      message: "unexpected relation",
+      context: "",
+    });
+    expect(p.toLowerCase()).toContain("validation");
+    expect(p).toContain("line 3");
+    expect(p).toContain("unexpected relation");
+  });
+
+  it("phrases a relationship error", () => {
+    const p = buildErrorPrompt({
+      source: DeveloperError_Source.RELATIONSHIP,
+      line: 2,
+      message: "invalid tuple",
+      context: "document:x#viewer@user:y",
+    });
+    expect(p.toLowerCase()).toContain("relationship");
+    expect(p).toContain("invalid tuple");
+  });
+});
+
+describe("buildCheckWatchPrompt", () => {
+  it("describes a denied (NOT_FOUND) check", () => {
+    const p = buildCheckWatchPrompt({
+      object: "document:budget",
+      action: "view",
+      subject: "user:tim",
+      context: "",
+      status: LiveCheckItemStatus.NOT_FOUND,
+    });
+    expect(p).toContain("document:budget#view@user:tim");
+    expect(p.toLowerCase()).toContain("denied");
+    expect(p.toLowerCase()).toContain("debug");
+  });
+
+  it("includes the error message for INVALID checks", () => {
+    const p = buildCheckWatchPrompt({
+      object: "document:x",
+      action: "edit",
+      subject: "user:sam",
+      context: "",
+      status: LiveCheckItemStatus.INVALID,
+      errorMessage: "unknown relation edit",
+    });
+    expect(p).toContain("unknown relation edit");
+  });
+
+  it("mentions missing context for CAVEATED checks", () => {
+    const p = buildCheckWatchPrompt({
+      object: "document:y",
+      action: "view",
+      subject: "user:kim",
+      context: "",
+      status: LiveCheckItemStatus.CAVEATED,
+    });
+    expect(p.toLowerCase()).toContain("context");
+  });
+});
+
+describe("isDebuggableWatchStatus", () => {
+  it("is true for non-passing, non-pending statuses", () => {
+    expect(isDebuggableWatchStatus(LiveCheckItemStatus.NOT_FOUND)).toBe(true);
+    expect(isDebuggableWatchStatus(LiveCheckItemStatus.INVALID)).toBe(true);
+    expect(isDebuggableWatchStatus(LiveCheckItemStatus.NOT_VALID)).toBe(true);
+    expect(isDebuggableWatchStatus(LiveCheckItemStatus.CAVEATED)).toBe(true);
+  });
+
+  it("is false for passing and pending statuses", () => {
+    expect(isDebuggableWatchStatus(LiveCheckItemStatus.FOUND)).toBe(false);
+    expect(isDebuggableWatchStatus(LiveCheckItemStatus.NOT_CHECKED)).toBe(false);
+  });
+});

--- a/src/services/assistant/debugPrompts.ts
+++ b/src/services/assistant/debugPrompts.ts
@@ -1,0 +1,104 @@
+import { DeveloperError_Source } from "../../spicedb-common/protodefs/developer/v1/developer_pb";
+import { LiveCheckItemStatus } from "../check";
+
+export interface ErrorPromptInput {
+  source: DeveloperError_Source;
+  line: number;
+  message: string;
+  context: string;
+}
+
+export interface CheckWatchPromptInput {
+  object: string;
+  action: string;
+  subject: string;
+  context: string;
+  status: LiveCheckItemStatus;
+  errorMessage?: string;
+}
+
+function linePart(line: number): string {
+  return line > 0 ? ` on line ${line}` : "";
+}
+
+function contextPart(context: string): string {
+  const trimmed = context.trim();
+  return trimmed ? ` (near \`${trimmed}\`)` : "";
+}
+
+/**
+ * buildErrorPrompt turns a schema/assertion/validation/relationship error into a
+ * short instruction that names the specific failure and asks the assistant to
+ * diagnose and fix it. The assistant already receives full document state each
+ * turn, so the prompt only needs to point at the failure — not re-embed the
+ * schema.
+ */
+export function buildErrorPrompt(input: ErrorPromptInput): string {
+  const { source, line, message, context } = input;
+  const quoted = `"${message.trim()}"`;
+  switch (source) {
+    case DeveloperError_Source.SCHEMA:
+      return `There's a schema error${linePart(line)}: ${quoted}${contextPart(
+        context,
+      )}. Diagnose the cause and fix the schema.`;
+    case DeveloperError_Source.ASSERTION: {
+      const assertion = context.trim() ? ` \`${context.trim()}\`` : "";
+      return `The assertion${assertion} is failing: ${quoted}. Investigate why and fix it — correct the schema or relationships if the assertion is right, or the assertion itself if it's wrong.`;
+    }
+    case DeveloperError_Source.VALIDATION_YAML:
+      return `There's a validation error${linePart(
+        line,
+      )}: ${quoted}. Investigate why the expected-relations validation is failing and fix it.`;
+    case DeveloperError_Source.RELATIONSHIP:
+      return `There's an error in the test relationships${linePart(line)}: ${quoted}${contextPart(
+        context,
+      )}. Fix the relationship.`;
+    default:
+      return `There's an error${linePart(line)}: ${quoted}${contextPart(
+        context,
+      )}. Diagnose the cause and fix it.`;
+  }
+}
+
+function watchStatusPhrase(status: LiveCheckItemStatus): string {
+  switch (status) {
+    case LiveCheckItemStatus.NOT_FOUND:
+      return "was denied";
+    case LiveCheckItemStatus.INVALID:
+      return "could not be evaluated";
+    case LiveCheckItemStatus.NOT_VALID:
+      return "could not be run against the current schema";
+    case LiveCheckItemStatus.CAVEATED:
+      return "is missing required context";
+    default:
+      return "did not succeed";
+  }
+}
+
+/**
+ * buildCheckWatchPrompt turns a failing live check watch into a debug request.
+ */
+export function buildCheckWatchPrompt(input: CheckWatchPromptInput): string {
+  const { object, action, subject, context, status, errorMessage } = input;
+  // Watch context is stored prefixed with "default:" by the Watches UI — strip
+  // it for readability in the prompt.
+  const rawContext = context.replace(/^default:/, "").trim();
+  const ctxPart = rawContext ? ` with context \`${rawContext}\`` : "";
+  const errPart = errorMessage?.trim() ? `: ${errorMessage.trim()}` : "";
+  return `The permission check \`${object}#${action}@${subject}\`${ctxPart} ${watchStatusPhrase(
+    status,
+  )}${errPart}. Debug why and fix it.`;
+}
+
+/**
+ * isDebuggableWatchStatus reports whether a watch is in a non-passing,
+ * non-pending state that warrants the "Ask assistant to debug" affordance.
+ */
+export function isDebuggableWatchStatus(status: LiveCheckItemStatus): boolean {
+  return (
+    status === LiveCheckItemStatus.NOT_FOUND ||
+    status === LiveCheckItemStatus.INVALID ||
+    status === LiveCheckItemStatus.NOT_VALID ||
+    status === LiveCheckItemStatus.CAVEATED
+  );
+}

--- a/src/services/assistant/debugRequest.test.ts
+++ b/src/services/assistant/debugRequest.test.ts
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("posthog-js", () => ({ default: { capture: vi.fn() } }));
+
+import posthog from "posthog-js";
+
+import { useRightDockStore } from "../../components/rightdock/state";
+
+import { requestAssistantDebug } from "./debugRequest";
+import { useAssistantStore } from "./store";
+
+describe("requestAssistantDebug", () => {
+  beforeEach(() => {
+    useAssistantStore.getState().reset();
+    useRightDockStore.getState().closeDock();
+    vi.clearAllMocks();
+  });
+
+  it("opens the assistant dock and sets the pending prompt", () => {
+    requestAssistantDebug("fix line 4", "editor");
+    expect(useAssistantStore.getState().pendingPrompt).toBe("fix line 4");
+    const dock = useRightDockStore.getState();
+    expect(dock.open).toBe(true);
+    expect(dock.activePanel).toBe("assistant");
+  });
+
+  it("captures a PostHog event tagged with the source", () => {
+    requestAssistantDebug("fix it", "watches");
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(posthog.capture).toHaveBeenCalledWith("playground_ai_debug_requested", {
+      source: "watches",
+    });
+  });
+});

--- a/src/services/assistant/debugRequest.ts
+++ b/src/services/assistant/debugRequest.ts
@@ -1,0 +1,20 @@
+import posthog from "posthog-js";
+
+import { useRightDockStore } from "../../components/rightdock/state";
+
+import { useAssistantStore } from "./store";
+
+export type DebugSource = "editor" | "watches" | "problems";
+
+/**
+ * requestAssistantDebug is the single entry point every inline/UI "Ask
+ * assistant to debug/fix" affordance calls. It opens the assistant dock panel
+ * (mounting AssistantPanel, whose usePendingPromptConsumer hook then submits)
+ * and stashes the prompt. A plain function (not a hook) so it is callable from
+ * React components AND from the module-scope Monaco CodeLens command handler.
+ */
+export function requestAssistantDebug(prompt: string, source: DebugSource): void {
+  posthog.capture("playground_ai_debug_requested", { source });
+  useRightDockStore.getState().openPanel("assistant");
+  useAssistantStore.getState().requestPrompt(prompt);
+}

--- a/src/services/assistant/store.test.ts
+++ b/src/services/assistant/store.test.ts
@@ -23,4 +23,17 @@ describe("useAssistantStore", () => {
     useAssistantStore.getState().reset();
     expect(useAssistantStore.getState().messages).toEqual([]);
   });
+
+  it("requestPrompt sets pendingPrompt and consumePrompt clears it", () => {
+    useAssistantStore.getState().requestPrompt("debug this");
+    expect(useAssistantStore.getState().pendingPrompt).toBe("debug this");
+    useAssistantStore.getState().consumePrompt();
+    expect(useAssistantStore.getState().pendingPrompt).toBeNull();
+  });
+
+  it("reset clears a pending prompt", () => {
+    useAssistantStore.getState().requestPrompt("debug this");
+    useAssistantStore.getState().reset();
+    expect(useAssistantStore.getState().pendingPrompt).toBeNull();
+  });
 });

--- a/src/services/assistant/store.ts
+++ b/src/services/assistant/store.ts
@@ -29,11 +29,18 @@ export interface AssistantState {
   // Bumped by reset() so an in-flight turn's async continuation can tell a
   // reset happened mid-turn and skip resurrecting stale results into the store.
   generation: number;
+  // A one-shot prompt requested from outside the panel (e.g. an inline "Ask
+  // assistant to fix" affordance). AssistantPanel consumes it on mount/idle and
+  // submits it. Transient — deliberately excluded from `partialize` so a reload
+  // never re-fires a stale request.
+  pendingPrompt: string | null;
   reset: () => void;
   setStatus: (s: AssistantStatus, error?: AssistantState["error"]) => void;
   appendUser: (text: string) => void;
   setMessages: (m: ChatMessage[]) => void;
   setDisplay: (d: DisplayMessage[]) => void;
+  requestPrompt: (text: string) => void;
+  consumePrompt: () => void;
 }
 
 const MAX_PERSISTED_MESSAGES = 40;
@@ -46,12 +53,14 @@ export const useAssistantStore = create<AssistantState>()(
       status: "idle",
       error: undefined,
       generation: 0,
+      pendingPrompt: null,
       reset: () =>
         set((s) => ({
           messages: [],
           display: [],
           status: "idle",
           error: undefined,
+          pendingPrompt: null,
           generation: s.generation + 1,
         })),
       setStatus: (status, error) => set({ status, error }),
@@ -65,6 +74,8 @@ export const useAssistantStore = create<AssistantState>()(
         })),
       setMessages: (messages) => set({ messages }),
       setDisplay: (display) => set({ display }),
+      requestPrompt: (text) => set({ pendingPrompt: text }),
+      consumePrompt: () => set({ pendingPrompt: null }),
     }),
     {
       name: "playground-assistant-state",

--- a/src/services/assistant/usePendingPrompt.ts
+++ b/src/services/assistant/usePendingPrompt.ts
@@ -1,0 +1,27 @@
+import { useEffect } from "react";
+
+import { useAssistantStore } from "./store";
+
+/**
+ * usePendingPromptConsumer drains a one-shot pendingPrompt (set by
+ * requestAssistantDebug) into the assistant turn. Mounted inside AssistantPanel,
+ * so opening the dock → mounting the panel → this effect fires the submit. It
+ * only waits while a turn is genuinely busy (streaming or executing tools —
+ * no lost click, no interrupting the running turn); it deliberately still
+ * fires from the terminal "error" state, since that state has no
+ * auto-transition back to "idle" and would otherwise dead-lock the affordance.
+ * Clears before submit to avoid a re-fire.
+ */
+export function usePendingPromptConsumer(submit: (text: string) => void): void {
+  const pendingPrompt = useAssistantStore((s) => s.pendingPrompt);
+  const status = useAssistantStore((s) => s.status);
+  const consumePrompt = useAssistantStore((s) => s.consumePrompt);
+
+  useEffect(() => {
+    const busy = status === "streaming" || status === "executing_tools";
+    if (!pendingPrompt || busy) return;
+    const text = pendingPrompt;
+    consumePrompt();
+    submit(text);
+  }, [pendingPrompt, status, submit, consumePrompt]);
+}

--- a/src/tests/browser/ask-assistant-actions.test.tsx
+++ b/src/tests/browser/ask-assistant-actions.test.tsx
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { render } from "vitest-browser-react";
+
+import { TooltipProvider } from "@/components/ui/tooltip";
+
+import {
+  AskAssistantDebugButton,
+  AskAssistantFixAction,
+} from "../../components/panels/AskAssistantActions";
+import { useRightDockStore } from "../../components/rightdock/state";
+import { useAssistantStore } from "../../services/assistant/store";
+import { LiveCheckItemStatus } from "../../services/check";
+import {
+  DeveloperError,
+  DeveloperError_Source,
+} from "../../spicedb-common/protodefs/developer/v1/developer_pb";
+
+const schemaError = {
+  message: "expected type",
+  line: 4,
+  column: 1,
+  source: DeveloperError_Source.SCHEMA,
+  context: "viewer",
+} as unknown as DeveloperError;
+
+describe("AskAssistantFixAction", () => {
+  beforeEach(() => {
+    useAssistantStore.getState().reset();
+    useRightDockStore.setState({ open: false, activePanel: null });
+  });
+
+  it("opens the assistant with a schema-fix prompt on click", async () => {
+    const screen = await render(
+      <TooltipProvider>
+        <AskAssistantFixAction error={schemaError} />
+      </TooltipProvider>,
+    );
+    await screen.getByRole("button", { name: /Ask assistant to fix/ }).click();
+    expect(useAssistantStore.getState().pendingPrompt).toContain("schema");
+    expect(useRightDockStore.getState().activePanel).toBe("assistant");
+    expect(useRightDockStore.getState().open).toBe(true);
+  });
+});
+
+describe("AskAssistantDebugButton", () => {
+  beforeEach(() => {
+    useAssistantStore.getState().reset();
+    useRightDockStore.setState({ open: false, activePanel: null });
+  });
+
+  it("opens the assistant with a check-watch prompt on click", async () => {
+    const item = {
+      id: "1",
+      object: "document:budget",
+      action: "view",
+      subject: "user:tim",
+      context: "",
+      status: LiveCheckItemStatus.NOT_FOUND,
+      errorMessage: undefined,
+    };
+    const screen = await render(
+      <TooltipProvider>
+        <AskAssistantDebugButton item={item} />
+      </TooltipProvider>,
+    );
+    await screen.getByRole("button", { name: "Ask assistant to debug" }).click();
+    expect(useAssistantStore.getState().pendingPrompt).toContain("document:budget#view@user:tim");
+    expect(useRightDockStore.getState().activePanel).toBe("assistant");
+    expect(useRightDockStore.getState().open).toBe(true);
+  });
+});

--- a/src/tests/browser/pending-prompt.test.tsx
+++ b/src/tests/browser/pending-prompt.test.tsx
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+
+import { useAssistantStore } from "../../services/assistant/store";
+import { usePendingPromptConsumer } from "../../services/assistant/usePendingPrompt";
+
+function Harness({ submit }: { submit: (text: string) => void }) {
+  usePendingPromptConsumer(submit);
+  return null;
+}
+
+describe("usePendingPromptConsumer", () => {
+  beforeEach(() => useAssistantStore.getState().reset());
+
+  it("submits and clears the pending prompt when idle", async () => {
+    const submit = vi.fn();
+    await render(<Harness submit={submit} />);
+    useAssistantStore.getState().requestPrompt("hello");
+    await vi.waitFor(() => expect(submit).toHaveBeenCalledWith("hello"));
+    expect(useAssistantStore.getState().pendingPrompt).toBeNull();
+  });
+
+  it("defers submission while a turn is in flight, then fires when idle", async () => {
+    const submit = vi.fn();
+    useAssistantStore.getState().setStatus("streaming");
+    await render(<Harness submit={submit} />);
+    useAssistantStore.getState().requestPrompt("later");
+    // Give the effect a chance to (not) run.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(submit).not.toHaveBeenCalled();
+    useAssistantStore.getState().setStatus("idle");
+    await vi.waitFor(() => expect(submit).toHaveBeenCalledWith("later"));
+  });
+
+  it("submits from a terminal error state (does not wait for idle)", async () => {
+    const submit = vi.fn();
+    useAssistantStore.getState().setStatus("error", { message: "boom" });
+    await render(<Harness submit={submit} />);
+    useAssistantStore.getState().requestPrompt("recover");
+    await vi.waitFor(() => expect(submit).toHaveBeenCalledWith("recover"));
+    expect(useAssistantStore.getState().pendingPrompt).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Adds one-click **"Ask assistant to debug/fix"** entry points that open the AI assistant and auto-submit a targeted debug prompt for a specific failure. The assistant already has the tools and full document state each turn, so this is purely the entry points plus one small new primitive.

## Surfaces (all gated on `AppConfig().aiEnabled` — nothing renders/registers when AI is off)

- **Schema syntax errors & failed assertions** — an inline "Ask assistant to fix" CodeLens in the schema/assertions editors, mirroring the existing `registerAssertionFixes` pattern.
- **Failing check watches** — an "Ask assistant to debug" button in the Watches panel for every non-passing state (denied / errored / couldn't-run / missing-context).
- **Problems panel** — an "Ask assistant to fix" action on schema, assertion, and validation error rows, alongside the existing "Add check watch".

## How it works

- A transient `pendingPrompt` on the assistant store (deliberately not persisted).
- `requestAssistantDebug(prompt, source)` opens the assistant dock and stashes the prompt; a `usePendingPromptConsumer` hook in `AssistantPanel` submits it once the panel isn't mid-turn. It defers only while a turn is actively streaming/executing tools — **not** on the terminal `error` state — so a request made after a failed turn still fires.
- A pure `debugPrompts.ts` builds the prompts (schema / assertion / validation / relationship errors, plus check watches), keeping wording consistent and testable.
- Analytics: a single `playground_ai_debug_requested` event tagged with `{ source: "editor" | "watches" | "problems" }`.

## Tests

- **Unit:** prompt builders + the `isDebuggableWatchStatus` predicate, the store's pending-prompt actions, and the `requestAssistantDebug` dispatcher.
- **Browser:** the affordance components (click → dock opens + prompt submitted) and the pending-prompt hook (idle, deferred-while-streaming, and fires-from-error).
- Full gate green: **unit 228, browser 47**, `vite build` clean, `oxfmt --check` clean, lint clean (no findings on changed files).

The inline editor CodeLens has no automated test by design, matching the existing untested `registerAssertionFixes`; its prompt output is covered by the builder unit tests.

## Notes

- Design spec and implementation plan live under `docs/superpowers/`.
- The four triggers were also verified live in-app with AI enabled.
