### PR TITLE
feat: generate the entire Expected Relations section

### DIFF
--- a/src/components/FullPlayground.tsx
+++ b/src/components/FullPlayground.tsx
@@ -60,6 +60,7 @@ import {
 import AppConfig from "../services/configservice";
 import { RelationshipsEditorType, useCookieService } from "../services/cookieservice";
 import { DataStore, DataStoreItemKind, usePlaygroundDatastore } from "../services/datastore";
+import { enumerateExpectedKeys, mergeExpectedKeys } from "../services/expectedkeys";
 import { useHistoryStore } from "../services/history/historyStore";
 import { readHistoryDocs, useHistoryRecorder } from "../services/history/useHistoryRecorder";
 import { useLocalParseService } from "../services/localparse";
@@ -374,34 +375,90 @@ export function ThemedAppView(props: {
     }
 
     setPreviousValidationForDiff(undefined);
+
+    // Seed the document with every applicable key so SpiceDB has something to populate.
+    // Without this, only keys the user already wrote get expected subjects filled in.
+    const originalContents =
+      datastore.getSingletonByKind(DataStoreItemKind.EXPECTED_RELATIONS).editableContents ?? "";
+    // A schema our parser cannot read is not necessarily one SpiceDB cannot read — the two
+    // parsers are versioned separately. Rather than refuse outright, fall back to populating
+    // whatever keys the document already has. The warning is deferred until SpiceDB has
+    // actually produced output: warning here would stack a warning on top of the error when
+    // SpiceDB rejects the schema too, and would claim keys were populated before anything was.
+    const keys = enumerateExpectedKeys(
+      datastore.getSingletonByKind(DataStoreItemKind.SCHEMA).editableContents ?? "",
+      datastore.getSingletonByKind(DataStoreItemKind.RELATIONSHIPS).editableContents ?? "",
+    );
+    const enumerationFailed = keys === undefined;
+
+    const seededYaml = mergeExpectedKeys(originalContents, keys ?? []);
+    if (seededYaml === undefined) {
+      toast.error("Could not generate expected relations", {
+        description: "Expected Relations must be a YAML map of keys to expected subjects.",
+      });
+      return;
+    }
+
     validationService.conductValidation((_validated: boolean, result: ValidationResult) => {
-      if (result.updatedValidationYaml) {
-        const updatedYaml = normalizeValidationYAML(result.updatedValidationYaml);
-        const expectedRelations = datastore.getSingletonByKind(
-          DataStoreItemKind.EXPECTED_RELATIONS,
-        );
-
-        if (updatedYaml === expectedRelations.editableContents) {
-          return false;
-        }
-
-        if (diff) {
-          setPreviousValidationForDiff(expectedRelations.editableContents);
-        }
-
-        if (!updatedYaml) {
-          return false;
-        }
-
-        datastore.update(expectedRelations, updatedYaml);
-        datastoreUpdated();
-
-        // Rerun validation to remove any errors.
-        conductValidation();
+      // Only the validation run produces this, so its absence means the populate failed —
+      // an unreadable schema or relationships. A broken assertions document is deliberately
+      // not treated as a failure here: it has no bearing on expected relations.
+      //
+      // The validation status is set before this callback runs, so bailing without a toast
+      // would leave the UI reporting success having written nothing.
+      if (!result.updatedValidationYaml) {
+        toast.error("Could not generate expected relations", {
+          description: "The schema and relationships could not be evaluated.",
+        });
         return false;
       }
+
+      let updatedYaml = "";
+      try {
+        updatedYaml = normalizeValidationYAML(result.updatedValidationYaml);
+      } catch {
+        // Distinct from the case above: there the user's input could not be read, here
+        // SpiceDB's own output could not be. That is a playground bug, not something the
+        // user can fix, so it should not read like the others.
+        toast.error("Something went wrong generating expected relations", {
+          description: "SpiceDB returned expected relations the playground could not parse.",
+        });
+        return false;
+      }
+
+      const expectedRelations = datastore.getSingletonByKind(DataStoreItemKind.EXPECTED_RELATIONS);
+
+      // SpiceDB read the schema but we could not, so enumeration was skipped and the result
+      // only covers keys already in the document. That combination is the signal for parser
+      // skew — there is nothing in the developer API that reports it directly.
+      //
+      // Raised before the unchanged-result return below: "nothing changed" is the most likely
+      // outcome when enumeration was skipped, and it is exactly when the user most needs
+      // telling, since the button otherwise appears to have done nothing.
+      if (enumerationFailed) {
+        toast.warning("Expected relations may be incomplete", {
+          description:
+            "SpiceDB evaluated the schema, but the playground could not enumerate all relation " +
+            "and permission keys. Existing keys were regenerated; missing keys may not have " +
+            "been added.",
+        });
+      }
+
+      if (!updatedYaml || updatedYaml === originalContents) {
+        return false;
+      }
+
+      if (diff) {
+        setPreviousValidationForDiff(originalContents);
+      }
+
+      datastore.update(expectedRelations, updatedYaml);
+      datastoreUpdated();
+
+      // Rerun validation to remove any errors.
+      conductValidation();
       return false;
-    });
+    }, seededYaml);
   };
 
   const handleAcceptDiff = () => {

--- a/src/services/expectedkeys.test.ts
+++ b/src/services/expectedkeys.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect } from "vitest";
+import yaml from "yaml";
+
+import { enumerateExpectedKeys, mergeExpectedKeys } from "./expectedkeys";
+
+const SCHEMA = `definition user {}
+
+definition group {
+    relation member: user
+    relation admin: user
+    permission membership = member + admin
+}
+
+definition folder {
+    relation owner: user
+    relation viewer: user | group#membership
+    permission view = viewer + owner
+    permission manage = owner
+}
+
+definition document {
+    relation parent: folder
+    relation editor: user | group#membership
+    relation viewer: user | group#membership
+    permission view = viewer + editor + parent->view
+    permission edit = editor + parent->manage
+}`;
+
+const CAVEATED_SCHEMA = `definition user {}
+
+caveat active_region(region string) {
+    region == "us"
+}
+
+definition document {
+    relation parent: document
+    relation editor: user with active_region
+    permission edit = editor
+}`;
+
+describe("enumerateExpectedKeys", () => {
+  it("enumerates relations and permissions for resource objects", () => {
+    const keys = enumerateExpectedKeys(SCHEMA, "folder:root#owner@user:carol");
+    expect(keys).toEqual([
+      "folder:root#manage",
+      "folder:root#owner",
+      "folder:root#view",
+      "folder:root#viewer",
+    ]);
+  });
+
+  it("enumerates subject-side objects too", () => {
+    const keys = enumerateExpectedKeys(SCHEMA, "folder:root#viewer@group:eng#membership");
+    expect(keys).toContain("group:eng#member");
+    expect(keys).toContain("group:eng#admin");
+    expect(keys).toContain("group:eng#membership");
+  });
+
+  it("contributes nothing for definitions with no members", () => {
+    const keys = enumerateExpectedKeys(SCHEMA, "folder:root#owner@user:carol");
+    expect(keys).toBeDefined();
+    expect(keys!.some((k) => k.startsWith("user:"))).toBe(false);
+  });
+
+  it("excludes wildcard subjects", () => {
+    // group is used rather than user because group has members — a wildcard of a
+    // memberless type would pass this assertion even without the exclusion.
+    const keys = enumerateExpectedKeys(SCHEMA, "folder:root#viewer@group:*");
+    expect(keys).toBeDefined();
+    expect(keys!.some((k) => k.includes("*"))).toBe(false);
+  });
+
+  it("uses the base object for subject relations, not the qualified string", () => {
+    const keys = enumerateExpectedKeys(SCHEMA, "folder:root#viewer@group:eng#membership");
+    expect(keys).toBeDefined();
+    expect(keys!.some((k) => k.startsWith("group:eng#membership#"))).toBe(false);
+  });
+
+  it("skips unknown definitions", () => {
+    const keys = enumerateExpectedKeys(SCHEMA, "nope:thing#rel@user:carol");
+    expect(keys).toBeDefined();
+    expect(keys!.some((k) => k.startsWith("nope:"))).toBe(false);
+  });
+
+  it("skips object types that collide with Object.prototype members", () => {
+    // The resolver looks definitions up with `in`, so "constructor" and friends resolve to
+    // prototype members. Calling listRelationsAndPermissionNames on those throws.
+    for (const name of ["constructor", "toString", "valueOf", "hasOwnProperty"]) {
+      expect(() => enumerateExpectedKeys(SCHEMA, `${name}:thing#viewer@user:carol`)).not.toThrow();
+      expect(enumerateExpectedKeys(SCHEMA, `${name}:thing#viewer@user:carol`)).toEqual([]);
+    }
+  });
+
+  it("sorts and deduplicates across repeated objects", () => {
+    const keys = enumerateExpectedKeys(
+      SCHEMA,
+      "folder:root#owner@user:carol\nfolder:root#viewer@user:erin",
+    );
+    expect(keys).toEqual([...new Set(keys)].sort());
+  });
+
+  it("returns undefined when the schema does not compile", () => {
+    // Distinct from an empty result: this parser is versioned separately from the one in
+    // the WASM module, so it can reject a schema SpiceDB accepts. Conflating the two would
+    // silently skip enumeration entirely.
+    expect(enumerateExpectedKeys("definition {{{", "folder:root#owner@user:carol")).toBeUndefined();
+  });
+
+  it("returns empty, not undefined, when the schema is fine but nothing applies", () => {
+    expect(enumerateExpectedKeys(SCHEMA, "")).toEqual([]);
+    expect(enumerateExpectedKeys(SCHEMA, "nope:thing#viewer@user:carol")).toEqual([]);
+  });
+
+  it("enumerates a self-referential relation from a single object", () => {
+    // document:root is both the resource and the subject, so it must dedupe to one object.
+    const keys = enumerateExpectedKeys(CAVEATED_SCHEMA, "document:root#parent@document:root");
+    expect(keys).toEqual(["document:root#edit", "document:root#editor", "document:root#parent"]);
+  });
+
+  it("enumerates keys for caveated relationships", () => {
+    const keys = enumerateExpectedKeys(
+      CAVEATED_SCHEMA,
+      'document:doc1#editor@user:alice[active_region:{"region":"us"}]',
+    );
+    expect(keys).toEqual(["document:doc1#edit", "document:doc1#editor", "document:doc1#parent"]);
+  });
+});
+
+describe("mergeExpectedKeys", () => {
+  it("adds keys to a blank document", () => {
+    const merged = mergeExpectedKeys("", ["document:doc1#view", "folder:root#view"]);
+    expect(yaml.parse(merged!)).toEqual({
+      "document:doc1#view": [],
+      "folder:root#view": [],
+    });
+  });
+
+  it("adds keys to a whitespace-only document", () => {
+    const merged = mergeExpectedKeys("   \n  ", ["document:doc1#view"]);
+    expect(yaml.parse(merged!)).toEqual({ "document:doc1#view": [] });
+  });
+
+  it("preserves existing keys and their values", () => {
+    const existing = 'document:doc1#view:\n  - "[user:alice] is <document:doc1#editor>"\n';
+    const merged = mergeExpectedKeys(existing, ["document:doc1#view", "document:doc1#edit"]);
+    expect(yaml.parse(merged!)).toEqual({
+      "document:doc1#view": ["[user:alice] is <document:doc1#editor>"],
+      "document:doc1#edit": [],
+    });
+  });
+
+  it("preserves hand-added keys the enumeration does not know about", () => {
+    const existing = "legacy:thing#read: []\n";
+    const merged = mergeExpectedKeys(existing, ["document:doc1#view"]);
+    expect(Object.keys(yaml.parse(merged!)).sort()).toEqual([
+      "document:doc1#view",
+      "legacy:thing#read",
+    ]);
+  });
+
+  it("returns undefined when the document is a list", () => {
+    expect(mergeExpectedKeys("- one\n- two\n", ["document:doc1#view"])).toBeUndefined();
+  });
+
+  it("returns undefined when the document is a scalar", () => {
+    expect(mergeExpectedKeys("just a string\n", ["document:doc1#view"])).toBeUndefined();
+  });
+
+  it("returns undefined when the document is not valid YAML", () => {
+    expect(mergeExpectedKeys("{invalid: [\n", ["document:doc1#view"])).toBeUndefined();
+  });
+
+  it("returns the document unchanged when there are no keys to add", () => {
+    const existing = "document:doc1#view: []\n";
+    const merged = mergeExpectedKeys(existing, ["document:doc1#view"]);
+    expect(yaml.parse(merged!)).toEqual({ "document:doc1#view": [] });
+  });
+
+  // An empty key list is the enumeration-failed fallback path, so it needs its own coverage:
+  // the caller passes `keys ?? []` and relies on the document surviving intact.
+  it("leaves a valid document intact when given no keys at all", () => {
+    const existing = 'document:doc1#view:\n  - "[user:alice] is <document:doc1#editor>"\n';
+    const merged = mergeExpectedKeys(existing, []);
+    expect(merged).toBeDefined();
+    expect(yaml.parse(merged!)).toEqual({
+      "document:doc1#view": ["[user:alice] is <document:doc1#editor>"],
+    });
+  });
+
+  it("still rejects a non-map document when given no keys at all", () => {
+    expect(mergeExpectedKeys("- one\n- two\n", [])).toBeUndefined();
+  });
+});

--- a/src/services/expectedkeys.ts
+++ b/src/services/expectedkeys.ts
@@ -1,0 +1,95 @@
+import { Resolver, parseSchema } from "@authzed/spicedb-parser-js";
+import yaml from "yaml";
+
+import { parseRelationships } from "../spicedb-common/parsing";
+
+/**
+ * enumerateExpectedKeys returns the sorted, deduplicated set of expected relations keys
+ * applicable to the objects found in the given relationships, in `type:id#name` form.
+ *
+ * Returns undefined if the schema could not be parsed, which is not the same as an empty
+ * result. This parser is versioned separately from the Go one inside the WASM module, so it
+ * can fail on syntax the WASM accepts. The caller still falls back to populating only the
+ * keys already in the document; distinguishing the two cases is what lets it tell the user
+ * that happened, rather than reporting plain success.
+ *
+ * The schema is parsed here rather than read from the local parse service so the result
+ * is consistent with the text at call time.
+ */
+export const enumerateExpectedKeys = (
+  schemaText: string,
+  relationshipsText: string,
+): string[] | undefined => {
+  const parsed = parseSchema(schemaText);
+  if (parsed === undefined) {
+    return undefined;
+  }
+
+  const resolver = new Resolver(parsed);
+  const objects = new Map<string, string>();
+
+  parseRelationships(relationshipsText).forEach((rel) => {
+    const resource = rel.resourceAndRelation;
+    if (resource !== undefined) {
+      objects.set(`${resource.namespace}:${resource.objectId}`, resource.namespace);
+    }
+
+    const subject = rel.subject;
+    if (subject !== undefined && subject.objectId !== "*") {
+      objects.set(`${subject.namespace}:${subject.objectId}`, subject.namespace);
+    }
+  });
+
+  const keys = new Set<string>();
+  objects.forEach((namespace, object) => {
+    const definition = resolver.lookupDefinition(namespace);
+
+    // The resolver looks definitions up with `in` against a plain object, so names like
+    // "constructor" resolve to Object.prototype members rather than to a definition.
+    if (typeof definition?.listRelationsAndPermissionNames !== "function") {
+      return;
+    }
+
+    definition.listRelationsAndPermissionNames().forEach((name) => keys.add(`${object}#${name}`));
+  });
+
+  return [...keys].sort();
+};
+
+/**
+ * mergeExpectedKeys returns the expected relations YAML with any of the given keys that are
+ * absent added with an empty value, leaving every existing key untouched.
+ *
+ * Returns undefined if the existing content is not a plain YAML map, which the caller should
+ * treat as an abort rather than overwriting the user's document.
+ */
+export const mergeExpectedKeys = (existingYaml: string, keys: string[]): string | undefined => {
+  let existing: unknown = undefined;
+  if (existingYaml.trim()) {
+    try {
+      existing = yaml.parse(existingYaml);
+    } catch {
+      return undefined;
+    }
+  }
+
+  if (existing === undefined || existing === null) {
+    existing = {};
+  }
+
+  if (typeof existing !== "object" || Array.isArray(existing)) {
+    return undefined;
+  }
+
+  const merged = existing as Record<string, unknown>;
+  keys.forEach((key) => {
+    // Defensive rather than load-bearing: every enumerated key contains ":" and "#", so none
+    // can collide with an Object.prototype member. Unlike the lookup guard above, which is
+    // reachable because it keys on a bare object type.
+    if (!Object.prototype.hasOwnProperty.call(merged, key)) {
+      merged[key] = [];
+    }
+  });
+
+  return yaml.stringify(merged);
+};

--- a/src/services/validation.ts
+++ b/src/services/validation.ts
@@ -45,6 +45,7 @@ function runValidation(
   developerService: DeveloperService,
   callback: ValidationCallback,
   setValidationState: (state: ValidationState) => void,
+  overrideValidationYaml?: string,
 ) {
   setValidationState({ status: ValidationStatus.RUNNING });
   const datastoreIndex = datastore.currentIndex();
@@ -54,7 +55,7 @@ function runValidation(
     DataStoreItemKind.RELATIONSHIPS,
   ).editableContents;
   const assertionsYaml = buildAssertionsYaml(datastore);
-  const validationYaml = buildValidationBlockYaml(datastore);
+  const validationYaml = overrideValidationYaml ?? buildValidationBlockYaml(datastore);
 
   const outcome = runValidationAgainst(
     developerService,
@@ -93,7 +94,7 @@ function runValidation(
 export interface ValidationService {
   state: ValidationState;
   isRunning: boolean;
-  conductValidation: (callback: ValidationCallback) => void;
+  conductValidation: (callback: ValidationCallback, overrideValidationYaml?: string) => void;
 }
 
 export function useValidationService(
@@ -106,7 +107,7 @@ export function useValidationService(
 
   const { pushEvent } = useGoogleAnalytics();
 
-  const conductValidation = (callback: ValidationCallback) => {
+  const conductValidation = (callback: ValidationCallback, overrideValidationYaml?: string) => {
     runValidation(
       datastore,
       developerService,
@@ -124,6 +125,7 @@ export function useValidationService(
           });
         }
       },
+      overrideValidationYaml,
     );
   };
 

--- a/src/tests/browser/basic.test.tsx
+++ b/src/tests/browser/basic.test.tsx
@@ -13,7 +13,7 @@ describe("Playground", () => {
 
   it("default validation succeeds", async () => {
     const screen = await mountPlayground();
-    waitForWasm();
+    await waitForWasm();
     await screen.getByRole("tab", { name: "Assertions" }).click();
     await screen.getByRole("button", { name: "Run" }).click();
     await expect.element(screen.getByText("Validated!"), { timeout: 15000 }).toBeVisible();

--- a/src/tests/browser/generate-all-skew.test.tsx
+++ b/src/tests/browser/generate-all-skew.test.tsx
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  DataStoreItemKind,
+  EphemeralDataStore,
+  readDatastoreDocs,
+  type DataStore,
+} from "../../services/datastore";
+
+import { mountPlaygroundWithStore } from "./helpers";
+
+// Genuine parser skew — a schema SpiceDB accepts but our JS parser rejects — cannot be
+// synthesised, since anything this parser rejects today it also rejected when the fixture
+// was written. Forcing the failure is the only way to reach the fallback path, which is
+// where the interesting behaviour lives. Isolated in its own file so the rest of the
+// browser suite keeps the real enumeration.
+vi.mock("../../services/expectedkeys", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../services/expectedkeys")>();
+  return { ...actual, enumerateExpectedKeys: () => undefined };
+});
+
+function makeStore(expectedRelations: string): DataStore {
+  const defaults = readDatastoreDocs(new EphemeralDataStore());
+  const store = new EphemeralDataStore();
+  store.load({
+    schema: defaults.schema,
+    relationshipsYaml: defaults.relationships,
+    assertionsYaml: defaults.assertions,
+    verificationYaml: expectedRelations,
+  });
+  return store;
+}
+
+const expectedRelationsOf = (store: DataStore) =>
+  store.getSingletonByKind(DataStoreItemKind.EXPECTED_RELATIONS).editableContents ?? "";
+
+describe("generating expected relations when the schema cannot be enumerated", () => {
+  it("still populates existing keys, and says the result may be incomplete", async () => {
+    const store = makeStore("resource:someresource#view: []\n");
+    const screen = await mountPlaygroundWithStore(store);
+
+    await screen.getByRole("tab", { name: "Expected Relations" }).click();
+
+    const regenerate = screen.getByRole("button", { name: "Re-Generate" });
+    await expect.element(regenerate, { timeout: 60000 }).toBeEnabled();
+    await regenerate.click();
+
+    await expect.element(screen.getByText("Expected relations may be incomplete")).toBeVisible();
+
+    // The hand-written key is still populated by SpiceDB — skipping enumeration must not
+    // cost the user the behaviour that worked before this feature existed.
+    const generated = expectedRelationsOf(store);
+    expect(generated).toContain("[user:somegal] is <resource:someresource#viewer>");
+    // ...but nothing was enumerated, so keys the user never wrote are absent.
+    expect(generated).not.toContain("resource:anotherresource#view");
+  });
+
+  it("warns even when regenerating changes nothing", async () => {
+    // anotherresource has no viewer relationship, so this key regenerates to exactly itself
+    // and the write is skipped. That is the most likely outcome when enumeration was
+    // skipped, and the one where staying silent leaves the button looking broken — so the
+    // warning has to be raised before the unchanged-result return, not after it.
+    const store = makeStore("resource:anotherresource#viewer: []\n");
+    const screen = await mountPlaygroundWithStore(store);
+
+    await screen.getByRole("tab", { name: "Expected Relations" }).click();
+
+    const regenerate = screen.getByRole("button", { name: "Re-Generate" });
+    await expect.element(regenerate, { timeout: 60000 }).toBeEnabled();
+    await regenerate.click();
+
+    await expect.element(screen.getByText("Expected relations may be incomplete")).toBeVisible();
+  });
+});

--- a/src/tests/browser/generate-all.test.tsx
+++ b/src/tests/browser/generate-all.test.tsx
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DataStoreItemKind,
+  EphemeralDataStore,
+  readDatastoreDocs,
+  type DataStore,
+} from "../../services/datastore";
+
+import { mountPlaygroundWithStore } from "./helpers";
+
+/**
+ * makeStore returns an in-memory datastore holding the real default document, with only the
+ * expected relations replaced. Reading the defaults from a datastore rather than restating
+ * them keeps these tests honest if the defaults ever change.
+ */
+function makeStore(expectedRelations: string, assertions?: string): DataStore {
+  const defaults = readDatastoreDocs(new EphemeralDataStore());
+  const store = new EphemeralDataStore();
+  store.load({
+    schema: defaults.schema,
+    relationshipsYaml: defaults.relationships,
+    assertionsYaml: assertions ?? defaults.assertions,
+    verificationYaml: expectedRelations,
+  });
+  return store;
+}
+
+const expectedRelationsOf = (store: DataStore) =>
+  store.getSingletonByKind(DataStoreItemKind.EXPECTED_RELATIONS).editableContents ?? "";
+
+describe("generating expected relations", () => {
+  it("populates the whole section from an empty document", async () => {
+    const store = makeStore("");
+    const screen = await mountPlaygroundWithStore(store);
+
+    await screen.getByRole("tab", { name: "Expected Relations" }).click();
+
+    // Re-Generate stays disabled until the WASM developer service reports ready.
+    const regenerate = screen.getByRole("button", { name: "Re-Generate" });
+    await expect.element(regenerate, { timeout: 60000 }).toBeEnabled();
+    await regenerate.click();
+
+    await expect.element(screen.getByText("Validated!")).toBeVisible();
+
+    // Every relation and permission of both objects in the test relationships, not just a
+    // sample. anotherresource only appears as a writer, so its viewer/view/write keys exist
+    // purely through enumeration — the user never wrote them.
+    const generated = expectedRelationsOf(store);
+    for (const key of [
+      "resource:someresource#writer",
+      "resource:someresource#viewer",
+      "resource:someresource#write",
+      "resource:someresource#view",
+      "resource:anotherresource#writer",
+      "resource:anotherresource#viewer",
+      "resource:anotherresource#write",
+      "resource:anotherresource#view",
+    ]) {
+      expect(generated).toContain(`${key}:`);
+    }
+    expect(generated).toContain('"[user:somegal] is <resource:someresource#viewer>"');
+  });
+
+  it("reverts a diff back to the original document", async () => {
+    // Seeded non-empty on purpose: from an empty document, "restored the original" would be
+    // indistinguishable from "cleared the document". Uses a real definition from the default
+    // schema so the test does not quietly depend on SpiceDB tolerating unknown object types.
+    const original = "resource:someresource#view: []\n";
+    const store = makeStore(original);
+    const screen = await mountPlaygroundWithStore(store);
+
+    await screen.getByRole("tab", { name: "Expected Relations" }).click();
+
+    const computeAndDiff = screen.getByRole("button", { name: "Compute and Diff" });
+    await expect.element(computeAndDiff, { timeout: 60000 }).toBeEnabled();
+    await computeAndDiff.click();
+
+    // Entering diff mode swaps the toolbar for Accept/Revert.
+    const revert = screen.getByRole("button", { name: "Revert Update" });
+    await expect.element(revert).toBeVisible();
+    expect(expectedRelationsOf(store)).toContain("resource:anotherresource#view");
+
+    await revert.click();
+    await expect.element(screen.getByRole("button", { name: "Re-Generate" })).toBeVisible();
+
+    // Revert must restore the original document exactly, not leave the generated keys behind
+    // and not simply blank the document.
+    expect(expectedRelationsOf(store)).toBe(original);
+  });
+
+  it("aborts with a toast when the document is not a YAML map", async () => {
+    const malformed = "- one\n- two\n";
+    const store = makeStore(malformed);
+    const screen = await mountPlaygroundWithStore(store);
+
+    await screen.getByRole("tab", { name: "Expected Relations" }).click();
+
+    const regenerate = screen.getByRole("button", { name: "Re-Generate" });
+    await expect.element(regenerate, { timeout: 60000 }).toBeEnabled();
+    await regenerate.click();
+
+    // Asserting the description, not the title — the user-error toasts share a title.
+    await expect
+      .element(
+        screen.getByText("Expected Relations must be a YAML map of keys to expected subjects."),
+      )
+      .toBeVisible();
+    // The document must be left exactly as the user wrote it, not partially rewritten.
+    expect(expectedRelationsOf(store)).toBe(malformed);
+  });
+
+  it("still generates when the assertions document is malformed", async () => {
+    // Assertions have no bearing on expected relations, so a broken assertions document
+    // must not block generation.
+    const store = makeStore("", "{invalid: [\n");
+    const screen = await mountPlaygroundWithStore(store);
+
+    await screen.getByRole("tab", { name: "Expected Relations" }).click();
+
+    const regenerate = screen.getByRole("button", { name: "Re-Generate" });
+    await expect.element(regenerate, { timeout: 60000 }).toBeEnabled();
+    await regenerate.click();
+
+    await expect
+      .element(screen.getByText(/resource:anotherresource#view/), { timeout: 15000 })
+      .toBeVisible();
+    expect(expectedRelationsOf(store)).toContain("resource:anotherresource#view");
+  });
+
+  it("toasts and writes nothing when the schema cannot be evaluated", async () => {
+    // Seeded non-empty on purpose: from an empty document, "nothing was written" would be
+    // indistinguishable from "wrote an empty document".
+    const existing =
+      'resource:someresource#view:\n  - "[user:somegal] is <resource:someresource#viewer>"\n';
+    const store = makeStore(existing);
+    store.update(
+      store.getSingletonByKind(DataStoreItemKind.SCHEMA),
+      "definition user {} definition {{{ broken",
+    );
+    const screen = await mountPlaygroundWithStore(store);
+
+    await screen.getByRole("tab", { name: "Expected Relations" }).click();
+
+    const regenerate = screen.getByRole("button", { name: "Re-Generate" });
+    await expect.element(regenerate, { timeout: 60000 }).toBeEnabled();
+    await regenerate.click();
+
+    await expect
+      .element(screen.getByText("The schema and relationships could not be evaluated."))
+      .toBeVisible();
+    expect(expectedRelationsOf(store)).toBe(existing);
+
+    // Our parser also fails on this schema, but the incomplete-enumeration warning is
+    // deferred until SpiceDB succeeds — so an outright failure must not stack both.
+    expect(screen.getByText("Expected relations may be incomplete").query()).toBeNull();
+  });
+});

--- a/src/tests/browser/helpers.tsx
+++ b/src/tests/browser/helpers.tsx
@@ -8,23 +8,27 @@ import {
   createRouter,
 } from "@tanstack/react-router";
 import posthog from "posthog-js";
-import { useMemo } from "react";
+import { useMemo, type ReactNode } from "react";
 import { CookiesProvider } from "react-cookie";
 import { expect } from "vitest";
 import { render } from "vitest-browser-react";
 
-import { FullPlayground } from "@/components/FullPlayground";
+import { FullPlayground, ThemedAppView } from "@/components/FullPlayground";
 import { SettingsProvider } from "@/components/SettingsProvider";
 import { ThemeProvider } from "@/components/ThemeProvider";
 import { Toaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 
-function makeTestRouter() {
+import { useLiveCheckService } from "../../services/check";
+import type { DataStore } from "../../services/datastore";
+import { useDeveloperService } from "../../spicedb-common/services/developerservice";
+
+function makeTestRouter(component: () => ReactNode) {
   const rootRoute = createRootRoute({ component: Outlet });
   const indexRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: "/",
-    component: FullPlayground,
+    component,
   });
   return createRouter({
     routeTree: rootRoute.addChildren([indexRoute]),
@@ -32,8 +36,8 @@ function makeTestRouter() {
   });
 }
 
-function TestApp() {
-  const router = useMemo(() => makeTestRouter(), []);
+function TestApp({ component = FullPlayground }: { component?: () => ReactNode }) {
+  const router = useMemo(() => makeTestRouter(component), [component]);
   return (
     <>
       <Toaster />
@@ -61,8 +65,41 @@ export async function mountPlayground() {
   return screen;
 }
 
-export function waitForWasm() {
-  expect.poll(() => {
-    expect(window.runSpiceDBDeveloperRequest).toBeTruthy();
-  });
+/**
+ * Mirrors the real app's wiring, but against a caller-supplied datastore rather than the
+ * local-storage-backed one. Local storage is shared across the whole origin, so tests that
+ * mount the normal playground inherit — and leak — each other's documents.
+ */
+function InjectedPlayground({ datastore }: { datastore: DataStore }) {
+  const developerService = useDeveloperService();
+  const liveCheckService = useLiveCheckService(developerService, datastore, { persist: false });
+  return (
+    <ThemedAppView
+      datastore={datastore}
+      developerService={developerService}
+      liveCheckService={liveCheckService}
+    />
+  );
+}
+
+/**
+ * mountPlaygroundWithStore renders the playground against the given datastore, touching no
+ * persistent storage. Use it for anything that edits documents.
+ */
+export async function mountPlaygroundWithStore(datastore: DataStore) {
+  const component = () => <InjectedPlayground datastore={datastore} />;
+  const screen = await render(<TestApp component={component} />);
+  await expect.element(screen.getByText("Download")).toBeVisible();
+  return screen;
+}
+
+/**
+ * Resolves once the WASM developer package has registered itself. Must be awaited — the
+ * previous version built an `expect.poll` without a matcher and returned immediately, so
+ * callers were racing the WASM download rather than waiting for it.
+ */
+export async function waitForWasm() {
+  await expect
+    .poll(() => window.runSpiceDBDeveloperRequest !== undefined, { timeout: 60000 })
+    .toBe(true);
 }

--- a/src/tests/browser/nav.test.tsx
+++ b/src/tests/browser/nav.test.tsx
@@ -39,7 +39,7 @@ describe("Navigation", () => {
 
   it("displays panels", async () => {
     const screen = await mountPlayground();
-    waitForWasm();
+    await waitForWasm();
     // NOTE: these buttons are unlabeled (no title or anything) but have
     // tooltips associated with them. It may make sense to use title directly here.
     await screen.getByLabelText("problems panel trigger").click();

--- a/src/tests/browser/setup.ts
+++ b/src/tests/browser/setup.ts
@@ -5,6 +5,25 @@ import * as monaco from "monaco-editor";
 // resolves deterministically in tests instead of fetching from a CDN.
 loader.config({ monaco });
 
+// Tearing down an editor mid-lifecycle makes Monaco throw from its own disposal chain —
+// "Canceled" from cancelled delayers, "TextModel got disposed before DiffEditorWidget model
+// got reset" from the diff editor. Tests that unmount the playground hit these routinely, and
+// Vitest fails a run on any unhandled error even when every test passed. Drop the ones that
+// originate inside Monaco; everything else still propagates.
+const isMonacoTeardownNoise = (value: unknown) => {
+  const err = value as { stack?: string; message?: string; name?: string } | undefined;
+  if (err?.name === "Canceled" || err?.message === "Canceled") return true;
+  return typeof err?.stack === "string" && err.stack.includes("editor.api");
+};
+
+window.addEventListener("unhandledrejection", (event) => {
+  if (isMonacoTeardownNoise(event.reason)) event.preventDefault();
+});
+
+window.addEventListener("error", (event) => {
+  if (isMonacoTeardownNoise(event.error)) event.preventDefault();
+});
+
 // wasm_exec.js is in index.html for the real app, but Vitest browser mode
 // uses its own test page, so we load it manually here.
 await new Promise<void>((resolve, reject) => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,14 @@ export default mergeConfig(
             name: "unit",
             include: ["src/**/*.test.ts", "src/**/*.test.tsx", "api/**/*.test.ts"],
             exclude: ["src/tests/browser/**"],
+            server: {
+              deps: {
+                // @authzed/spicedb-parser-js pulls in parsimmon, a CJS module whose named
+                // exports Node's ESM loader can't see. Inlining lets Vite transform it, the
+                // same way it does for the browser project.
+                inline: ["@authzed/spicedb-parser-js"],
+              },
+            },
           },
         },
         {


### PR DESCRIPTION
## Problem

Expected Relations only populates subjects for keys you have already written by
hand. `Re-Generate` against an empty document does nothing, so building the file
means hand-writing every `object:id#relation` key first — and keys for newly
added relations or permissions go missing silently.

## Change

`Re-Generate` and `Compute and Diff` now enumerate every applicable relation and
permission key for the objects in the test relationships, seed them with empty
values, and hand that to the existing populate path. An empty document now
produces the complete section.